### PR TITLE
feat: Zendesk SVG transparent background and separate size controls

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -157,6 +157,8 @@ export default function Home() {
               onIconColorChange={actions.setIconColor}
               iconSize={state.iconSize}
               onIconSizeChange={actions.setIconSize}
+              svgIconSize={state.svgIconSize}
+              onSvgIconSizeChange={actions.setSvgIconSize}
               selectedIconId={state.selectedIconId}
             />
           </div>

--- a/docs/zendesk-icon-docs.md
+++ b/docs/zendesk-icon-docs.md
@@ -9,6 +9,20 @@
 ### Location-Specific Icons
 - `assets/icon_*.svg` — An app in the nav_bar, ticket_editor, or top_bar location requires a respective `icon_nav_bar.svg`, `icon_ticket_editor.svg` or `icon_top_bar.svg` file. See SVG app icons and Top bar, nav bar, and ticket editor icon for the image specifications. Sized via viewBox but visually optimized for 18×18 display inside a 30×30 padded box.
 
+#### Critical SVG Requirements for Location Icons
+These location-specific SVG icons have strict requirements different from PNG logos:
+
+1. **Transparent Background**: The SVG must NOT contain a background element (no `<rect>` fill). Zendesk applies its own background styling.
+
+2. **No Hardcoded Fill Colors**: Do not specify explicit fill colors in the SVG. Use `currentColor` or omit the fill attribute entirely. Zendesk applies consistent fill colors across all app icons via CSS to maintain visual cohesion and proper hover/active states.
+
+3. **Why This Matters**: Hardcoding colors or backgrounds will:
+   - Cause visual inconsistencies with other Zendesk app icons
+   - Interfere with hover and active states controlled by Zendesk CSS
+   - Appear broken on different Zendesk themes (light/dark)
+
+This generator automatically exports `icon_top_bar.svg`, `icon_ticket_editor.svg`, and `icon_nav_bar.svg` with transparent backgrounds and `currentColor` fills to comply with these requirements.
+
 ## File & Naming Conventions
 - Store all assets in the app `assets/` directory.
 - Keep filenames lowercase with underscores where required; follow Zendesk defaults without introducing additional extensions.
@@ -19,6 +33,7 @@
 - Design on square artboards; align stroking and padding to avoid blurring.
 - Ensure visibility on both light and dark backgrounds (preview against both).
 - Leave corners square; Zendesk applies its own rounding mask.
+- For location SVGs (top bar, ticket editor, nav bar): rely on `currentColor` for fill/stroke so Zendesk can control the color via CSS.
 
 ## License Considerations
 - Only bundle icon packs under compatible licenses (e.g., Apache-2.0).

--- a/src/hooks/use-icon-generator.ts
+++ b/src/hooks/use-icon-generator.ts
@@ -17,7 +17,10 @@ export interface IconGeneratorState {
   iconColor: string;
   searchQuery: string;
   selectedPack: IconPack;
+  /** Icon size for PNG exports */
   iconSize: number;
+  /** Icon size for SVG exports (top_bar, ticket_editor, nav_bar) */
+  svgIconSize: number;
 }
 
 export interface IconGeneratorActions {
@@ -28,6 +31,7 @@ export interface IconGeneratorActions {
   setSearchQuery: (query: string) => void;
   setSelectedPack: (pack: IconPack) => void;
   setIconSize: (size: number) => void;
+  setSvgIconSize: (size: number) => void;
 }
 
 const DEFAULT_STATE: IconGeneratorState = {
@@ -38,6 +42,7 @@ const DEFAULT_STATE: IconGeneratorState = {
   searchQuery: "",
   selectedPack: ICON_PACKS.ALL,
   iconSize: 123,
+  svgIconSize: 123,
 };
 
 export function useIconGenerator() {
@@ -77,6 +82,9 @@ export function useIconGenerator() {
           iconSize: typeof persistedState.iconSize === "number" && persistedState.iconSize > 0
             ? persistedState.iconSize
             : DEFAULT_STATE.iconSize,
+          svgIconSize: typeof persistedState.svgIconSize === "number" && persistedState.svgIconSize > 0
+            ? persistedState.svgIconSize
+            : DEFAULT_STATE.svgIconSize,
         };
         hasPersistedIcon = !!restoredState.selectedIconId;
         setState(restoredState);
@@ -118,6 +126,7 @@ export function useIconGenerator() {
       iconColor: state.iconColor,
       selectedPack: state.selectedPack,
       iconSize: state.iconSize,
+      svgIconSize: state.svgIconSize,
     });
   }, [
     hasInitialized,
@@ -128,6 +137,7 @@ export function useIconGenerator() {
     state.iconColor,
     state.selectedPack,
     state.iconSize,
+    state.svgIconSize,
   ]);
 
   const actions: IconGeneratorActions = React.useMemo(
@@ -146,6 +156,8 @@ export function useIconGenerator() {
         setState((prev) => ({ ...prev, selectedPack: pack })),
       setIconSize: (size) =>
         setState((prev) => ({ ...prev, iconSize: size })),
+      setSvgIconSize: (size) =>
+        setState((prev) => ({ ...prev, svgIconSize: size })),
     }),
     []
   );

--- a/src/utils/local-storage.ts
+++ b/src/utils/local-storage.ts
@@ -160,6 +160,7 @@ export interface PersistedGeneratorState {
   iconColor: string;
   selectedPack: string;
   iconSize: number;
+  svgIconSize?: number;
 }
 
 /**


### PR DESCRIPTION
Implements Zendesk-compliant SVG exports for location icons (top_bar, ticket_editor, nav_bar) with transparent backgrounds and currentColor fills.

## Changes
- Add transparent background mode for Zendesk location SVGs (no background element)
- Preserve currentColor in SVGs for Zendesk CSS styling (no hardcoded fills)
- Add separate SVG icon size slider (48-300px) independent from PNG size
- Update preview to show checkered background for transparent SVGs
- Fix preview sizing to match actual SVG output (64×64px)

## Zendesk Compliance
- SVGs for top_bar, ticket_editor, and nav_bar now have transparent backgrounds
- Icons use currentColor instead of hardcoded fill colors
- Matches Zendesk requirements: https://developer.zendesk.com/documentation/apps/app-developer-guide/styling/

Closes #11