### PR TITLE
feat: add agent-focused SVG API and docs endpoints

### DIFF
--- a/app/api-docs.md/route.ts
+++ b/app/api-docs.md/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { injectDocsBaseUrl, resolveDocsBaseUrl } from "@/src/utils/api-docs";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  try {
+    const filePath = path.join(process.cwd(), "docs", "api-reference.md");
+    const markdown = await readFile(filePath, "utf-8");
+    const baseUrl = resolveDocsBaseUrl({
+      host:
+        request.headers.get("x-forwarded-host") ?? request.headers.get("host"),
+      forwardedProto: request.headers.get("x-forwarded-proto"),
+    });
+    const resolvedMarkdown = injectDocsBaseUrl(markdown, baseUrl);
+
+    return new NextResponse(resolvedMarkdown, {
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to read API docs";
+    return NextResponse.json(
+      {
+        error: "api_docs_read_failed",
+        message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { headers } from "next/headers";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { injectDocsBaseUrl, resolveDocsBaseUrl } from "@/src/utils/api-docs";
+
+export const metadata: Metadata = {
+  title: "API Docs",
+  description: "Icon Generator API reference for AI agents and scripts.",
+};
+
+async function loadApiReferenceMarkdown(): Promise<string> {
+  const filePath = path.join(process.cwd(), "docs", "api-reference.md");
+  return readFile(filePath, "utf-8");
+}
+
+export default async function ApiDocsPage() {
+  const markdown = await loadApiReferenceMarkdown();
+  const requestHeaders = await headers();
+  const baseUrl = resolveDocsBaseUrl({
+    host: requestHeaders.get("x-forwarded-host") ?? requestHeaders.get("host"),
+    forwardedProto: requestHeaders.get("x-forwarded-proto"),
+  });
+  const resolvedMarkdown = injectDocsBaseUrl(markdown, baseUrl);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto w-full max-w-5xl px-6 py-10">
+        <div className="mb-6 flex items-center justify-between gap-4">
+          <h1 className="text-3xl font-semibold">Icon Generator API Docs</h1>
+          <Link
+            href="/api-docs.md"
+            className="rounded border px-3 py-2 text-sm hover:bg-muted"
+          >
+            View raw markdown
+          </Link>
+        </div>
+
+        <section className="mb-6 rounded-lg border bg-muted/30 p-5">
+          <h2 className="text-xl font-semibold">What this API is for</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            This API gives AI agents and scripts a predictable way to discover
+            icons, configure style options, and generate final SVG assets that
+            can be transformed into PNG/ICO externally.
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Active base URL: <code>{baseUrl}</code>
+          </p>
+          <div className="mt-4 grid gap-3 text-sm md:grid-cols-3">
+            <div className="rounded-md border bg-background p-3">
+              <p className="font-medium">Discover</p>
+              <p className="mt-1 text-muted-foreground">
+                Search icons, list packs/categories, and inspect icon metadata.
+              </p>
+            </div>
+            <div className="rounded-md border bg-background p-3">
+              <p className="font-medium">Generate</p>
+              <p className="mt-1 text-muted-foreground">
+                Produce SVG with solid/gradient backgrounds, color, and scale
+                controls.
+              </p>
+            </div>
+            <div className="rounded-md border bg-background p-3">
+              <p className="font-medium">Integrate</p>
+              <p className="mt-1 text-muted-foreground">
+                Use HTTP, curl, or agent workflows; consume JSON or raw SVG.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <pre className="overflow-x-auto rounded-lg border bg-muted p-5 text-sm leading-6 whitespace-pre-wrap">
+          {resolvedMarkdown}
+        </pre>
+      </div>
+    </main>
+  );
+}

--- a/app/api/__tests__/routes.test.ts
+++ b/app/api/__tests__/routes.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET as getIconsRoute } from "../icons/route";
+import { GET as getIconByIdRoute } from "../icons/[id]/route";
+import { POST as postGenerateRoute } from "../generate/route";
+import {
+  getIconByIdServer,
+  searchIconsServer,
+} from "@/src/utils/icon-catalog-server";
+import { renderSvgServer } from "@/src/utils/renderer-server";
+
+vi.mock("@/src/utils/icon-catalog-server", () => ({
+  searchIconsServer: vi.fn(),
+  getIconByIdServer: vi.fn(),
+}));
+
+vi.mock("@/src/utils/renderer-server", () => ({
+  renderSvgServer: vi.fn(),
+}));
+
+describe("API routes", () => {
+  beforeEach(() => {
+    vi.mocked(searchIconsServer).mockReset();
+    vi.mocked(getIconByIdServer).mockReset();
+    vi.mocked(renderSvgServer).mockReset();
+  });
+
+  it("returns filtered icon metadata for /api/icons", async () => {
+    vi.mocked(searchIconsServer).mockResolvedValue([
+      {
+        id: "feather-star",
+        name: "Star",
+        pack: "feather",
+        svg: "<svg />",
+        keywords: ["star"],
+      },
+    ]);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/icons?q=star&limit=10"
+    );
+    const response = await getIconsRoute(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.count).toBe(1);
+    expect(body.icons[0].id).toBe("feather-star");
+    expect(body.icons[0].svg).toBeUndefined();
+  });
+
+  it("returns 404 for unknown icon in /api/icons/[id]", async () => {
+    vi.mocked(getIconByIdServer).mockResolvedValue(null);
+    const request = new NextRequest("http://localhost:3000/api/icons/missing");
+
+    const response = await getIconByIdRoute(request, {
+      params: Promise.resolve({ id: "missing" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns JSON payload for /api/generate by default", async () => {
+    vi.mocked(getIconByIdServer).mockResolvedValue({
+      id: "feather-star",
+      name: "Star",
+      pack: "feather",
+      svg: '<svg viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+      keywords: ["star"],
+    });
+    vi.mocked(renderSvgServer).mockReturnValue("<svg>rendered</svg>");
+
+    const request = new NextRequest("http://localhost:3000/api/generate", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: JSON.stringify({
+        iconId: "feather-star",
+        backgroundColor: "#063940",
+        iconColor: "#ffffff",
+        size: 128,
+      }),
+    });
+
+    const response = await postGenerateRoute(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.svg).toBe("<svg>rendered</svg>");
+    expect(body.icon.id).toBe("feather-star");
+  });
+
+  it("returns raw SVG when Accept header requests image/svg+xml", async () => {
+    vi.mocked(getIconByIdServer).mockResolvedValue({
+      id: "feather-star",
+      name: "Star",
+      pack: "feather",
+      svg: '<svg viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+      keywords: ["star"],
+    });
+    vi.mocked(renderSvgServer).mockReturnValue("<svg>raw</svg>");
+
+    const request = new NextRequest("http://localhost:3000/api/generate", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "image/svg+xml",
+      },
+      body: JSON.stringify({
+        iconId: "feather-star",
+        backgroundColor: "#063940",
+        iconColor: "#ffffff",
+        size: 128,
+      }),
+    });
+
+    const response = await postGenerateRoute(request);
+    const text = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("image/svg+xml");
+    expect(text).toBe("<svg>raw</svg>");
+  });
+
+  it("returns validation error when /api/generate payload is invalid", async () => {
+    const request = new NextRequest("http://localhost:3000/api/generate", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        iconId: "",
+        backgroundColor: "not-a-color",
+      }),
+    });
+
+    const response = await postGenerateRoute(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("validation_failed");
+  });
+});

--- a/app/api/config/gradients/route.ts
+++ b/app/api/config/gradients/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import {
+  getGradientPreset,
+  getGradientPresetNames,
+} from "@/src/utils/gradients";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const presetNames = getGradientPresetNames();
+    const presets = presetNames.map((name) => ({
+      name,
+      value: getGradientPreset(name),
+    }));
+
+    return NextResponse.json({
+      count: presets.length,
+      presets,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to list gradients";
+    return NextResponse.json(
+      {
+        error: "gradients_read_failed",
+        message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/config/locations/route.ts
+++ b/app/api/config/locations/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import {
+  APP_LOCATIONS,
+  getLocationsRequiringIcons,
+} from "@/src/types/app-location";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const locationsRequiringIcons = getLocationsRequiringIcons().map(
+      (location) => location.value
+    );
+
+    return NextResponse.json({
+      count: APP_LOCATIONS.length,
+      locationsRequiringIcons,
+      locations: APP_LOCATIONS,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to list locations";
+    return NextResponse.json(
+      {
+        error: "locations_read_failed",
+        message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getIconByIdServer } from "@/src/utils/icon-catalog-server";
+import { renderSvgServer } from "@/src/utils/renderer-server";
+
+export const runtime = "nodejs";
+
+const hexColorSchema = z.string().regex(/^#[0-9a-fA-F]{6}$/, {
+  message: "Expected color in #RRGGBB format",
+});
+
+const gradientStopSchema = z.object({
+  color: hexColorSchema,
+  offset: z.number().min(0).max(100),
+});
+
+const linearGradientSchema = z.object({
+  type: z.literal("linear"),
+  angle: z.number(),
+  stops: z.array(gradientStopSchema).min(2),
+});
+
+const radialGradientSchema = z.object({
+  type: z.literal("radial"),
+  centerX: z.number().min(0).max(100),
+  centerY: z.number().min(0).max(100),
+  radius: z.number().min(0).max(100),
+  stops: z.array(gradientStopSchema).min(2),
+});
+
+const backgroundSchema = z.union([
+  hexColorSchema,
+  linearGradientSchema,
+  radialGradientSchema,
+]);
+
+const generateRequestSchema = z.object({
+  iconId: z.string().min(1),
+  backgroundColor: backgroundSchema.default("#063940"),
+  iconColor: hexColorSchema.default("#ffffff"),
+  size: z.number().int().min(48).max(300).default(128),
+  padding: z.number().min(-200).max(200).optional(),
+  outputSize: z.number().int().min(16).max(4096).optional(),
+  zendeskLocationMode: z.boolean().default(false),
+  filename: z.string().min(1).max(120).optional(),
+});
+
+function shouldReturnRawSvg(request: NextRequest): boolean {
+  const explicitFormat = request.nextUrl.searchParams.get("format");
+  if (explicitFormat) {
+    return explicitFormat.toLowerCase() === "svg";
+  }
+
+  const accept = request.headers.get("accept")?.toLowerCase() ?? "";
+  return accept.includes("image/svg+xml");
+}
+
+function createDownloadFilename(requestedFilename: string | undefined): string {
+  if (!requestedFilename) {
+    return "generated-icon.svg";
+  }
+
+  const sanitized = requestedFilename.replace(/[^a-zA-Z0-9._-]/g, "-");
+  return sanitized.endsWith(".svg") ? sanitized : `${sanitized}.svg`;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const parsedBody = generateRequestSchema.safeParse(await request.json());
+
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        {
+          error: "validation_failed",
+          message: "Invalid request body",
+          details: parsedBody.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const payload = parsedBody.data;
+    const icon = await getIconByIdServer(payload.iconId);
+    if (!icon) {
+      return NextResponse.json(
+        {
+          error: "icon_not_found",
+          message: `Icon '${payload.iconId}' was not found`,
+        },
+        { status: 404 }
+      );
+    }
+
+    const svg = renderSvgServer({
+      icon,
+      backgroundColor: payload.backgroundColor,
+      iconColor: payload.iconColor,
+      size: payload.size,
+      padding: payload.padding,
+      outputSize: payload.outputSize,
+      zendeskLocationMode: payload.zendeskLocationMode,
+    });
+
+    if (shouldReturnRawSvg(request)) {
+      const filename = createDownloadFilename(payload.filename);
+      return new NextResponse(svg, {
+        headers: {
+          "Content-Type": "image/svg+xml; charset=utf-8",
+          "Cache-Control": "no-store",
+          "Content-Disposition": `inline; filename="${filename}"`,
+        },
+      });
+    }
+
+    return NextResponse.json({
+      icon: {
+        id: icon.id,
+        name: icon.name,
+        pack: icon.pack,
+      },
+      settings: {
+        backgroundColor: payload.backgroundColor,
+        iconColor: payload.iconColor,
+        size: payload.size,
+        padding: payload.padding ?? 0,
+        outputSize: payload.outputSize ?? payload.size,
+        zendeskLocationMode: payload.zendeskLocationMode,
+      },
+      svg,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to generate SVG";
+    return NextResponse.json(
+      {
+        error: "svg_generation_failed",
+        message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/icons/[id]/route.ts
+++ b/app/api/icons/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIconByIdServer } from "@/src/utils/icon-catalog-server";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await context.params;
+    const decodedId = decodeURIComponent(id);
+    const icon = await getIconByIdServer(decodedId);
+
+    if (!icon) {
+      return NextResponse.json(
+        {
+          error: "icon_not_found",
+          message: `Icon '${decodedId}' was not found`,
+        },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      id: icon.id,
+      name: icon.name,
+      pack: icon.pack,
+      variant: icon.variant,
+      keywords: icon.keywords,
+      category: icon.category,
+      size: icon.size,
+      isRasterized: icon.isRasterized ?? false,
+      svg: icon.svg,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to get icon";
+    return NextResponse.json(
+      {
+        error: "icon_read_failed",
+        message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/icons/categories/route.ts
+++ b/app/api/icons/categories/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { getRemixIconCategoriesServer } from "@/src/utils/icon-catalog-server";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const categories = await getRemixIconCategoriesServer();
+    return NextResponse.json({
+      count: categories.length,
+      categories,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to list categories";
+    return NextResponse.json(
+      {
+        error: "categories_read_failed",
+        message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/icons/packs/route.ts
+++ b/app/api/icons/packs/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { getIconPacksServer } from "@/src/utils/icon-catalog-server";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const packs = await getIconPacksServer();
+    return NextResponse.json({
+      count: packs.length,
+      packs,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to list icon packs";
+    return NextResponse.json(
+      {
+        error: "packs_read_failed",
+        message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/icons/route.ts
+++ b/app/api/icons/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  searchIconsServer,
+  type ApiIconPack,
+} from "@/src/utils/icon-catalog-server";
+
+export const runtime = "nodejs";
+
+const API_ICON_PACKS: ApiIconPack[] = [
+  "all",
+  "garden",
+  "zendesk-garden",
+  "feather",
+  "remixicon",
+  "emoji",
+  "custom-svg",
+  "custom-image",
+];
+
+function normalizePackParam(pack: string | null): ApiIconPack {
+  if (!pack) {
+    return "all";
+  }
+
+  return API_ICON_PACKS.includes(pack as ApiIconPack)
+    ? (pack as ApiIconPack)
+    : "all";
+}
+
+function toSafeInteger(
+  value: string | null,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return Math.min(max, Math.max(min, parsed));
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const q = searchParams.get("q") ?? "";
+    const pack = normalizePackParam(searchParams.get("pack"));
+    const category = searchParams.get("category");
+    const limit = toSafeInteger(searchParams.get("limit"), 50, 1, 250);
+    const offset = toSafeInteger(searchParams.get("offset"), 0, 0, 10000);
+
+    const icons = await searchIconsServer({
+      query: q,
+      pack,
+      category,
+      limit,
+      offset,
+    });
+
+    return NextResponse.json({
+      query: {
+        q,
+        pack,
+        category,
+        limit,
+        offset,
+      },
+      count: icons.length,
+      icons: icons.map((icon) => ({
+        id: icon.id,
+        name: icon.name,
+        pack: icon.pack,
+        variant: icon.variant,
+        keywords: icon.keywords,
+        category: icon.category,
+        size: icon.size,
+        isRasterized: icon.isRasterized ?? false,
+      })),
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to search icons";
+
+    return NextResponse.json(
+      {
+        error: "icons_search_failed",
+        message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,7 @@ import {
   Info,
   Github,
   Globe,
+  BookOpen,
   Moon,
   Sun,
   Lock,
@@ -189,6 +190,12 @@ export default function Home() {
             <p className="text-sm text-muted-foreground">{APP_DESCRIPTION}</p>
           </div>
           <div className="flex items-center gap-2">
+            <Button variant="ghost" size="sm" className="shrink-0" asChild>
+              <Link href="/api-docs" aria-label="Open API documentation">
+                <BookOpen className="h-4 w-4" />
+                API Docs
+              </Link>
+            </Button>
             {!isRestrictionLoading && !isRestricted && (
               <Button
                 variant="ghost"

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "zdk-icon-generator",
@@ -36,6 +35,7 @@
         "react-dropzone": "^14.3.8",
         "remixicon": "^4.7.0",
         "tailwind-merge": "^3.4.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
@@ -1453,7 +1453,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
@@ -1532,6 +1532,8 @@
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "eslint-plugin-react-hooks/zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
 
     "fabric/jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,170 @@
+# Icon Generator API Reference
+
+This API is designed for AI agents and automation scripts.
+
+- Base URL: `{{BASE_URL}}`
+- Output focus: SVG generation
+- Suggested flow:
+  1. Search icon
+  2. Read icon metadata
+  3. Generate SVG
+  4. Convert SVG to PNG/ICO externally (Python/ImageMagick/etc.)
+
+## Endpoints
+
+### `GET /api/icons`
+
+Search and filter icons.
+
+Query params:
+
+- `q` (optional): search text
+- `pack` (optional): `all`, `garden`, `zendesk-garden`, `feather`, `remixicon`, `emoji`, `custom-svg`, `custom-image`
+- `category` (optional): category name (mainly for RemixIcon)
+- `limit` (optional, default `50`, max `250`)
+- `offset` (optional, default `0`)
+
+Example:
+
+```bash
+curl "{{BASE_URL}}/api/icons?q=star&pack=feather&limit=5"
+```
+
+### `GET /api/icons/[id]`
+
+Get a single icon metadata payload including SVG source.
+
+Example:
+
+```bash
+curl "{{BASE_URL}}/api/icons/feather-star"
+```
+
+### `GET /api/icons/packs`
+
+List packs, counts, and license metadata.
+
+```bash
+curl "{{BASE_URL}}/api/icons/packs"
+```
+
+### `GET /api/icons/categories`
+
+List RemixIcon categories.
+
+```bash
+curl "{{BASE_URL}}/api/icons/categories"
+```
+
+### `GET /api/config/gradients`
+
+List named gradient presets and values.
+
+```bash
+curl "{{BASE_URL}}/api/config/gradients"
+```
+
+### `GET /api/config/locations`
+
+List Zendesk app locations and which ones require icon SVGs.
+
+```bash
+curl "{{BASE_URL}}/api/config/locations"
+```
+
+### `POST /api/generate`
+
+Generate an SVG icon from an icon id and style options.
+
+Request body:
+
+```json
+{
+  "iconId": "feather-star",
+  "backgroundColor": "#063940",
+  "iconColor": "#ffffff",
+  "size": 128,
+  "padding": 0,
+  "outputSize": 128,
+  "zendeskLocationMode": false,
+  "filename": "logo.svg"
+}
+```
+
+Rules:
+
+- `iconId`: required string
+- `backgroundColor`: `#RRGGBB` or a gradient object
+- `iconColor`: `#RRGGBB`
+- `size`: integer `48..300`
+- `padding`: optional `-200..200`
+- `outputSize`: optional integer `16..4096`
+- `zendeskLocationMode`: optional boolean
+
+Linear gradient background:
+
+```json
+{
+  "type": "linear",
+  "angle": 135,
+  "stops": [
+    { "color": "#667eea", "offset": 0 },
+    { "color": "#764ba2", "offset": 100 }
+  ]
+}
+```
+
+Radial gradient background:
+
+```json
+{
+  "type": "radial",
+  "centerX": 50,
+  "centerY": 50,
+  "radius": 70,
+  "stops": [
+    { "color": "#ff0080", "offset": 0 },
+    { "color": "#7928ca", "offset": 100 }
+  ]
+}
+```
+
+Generate JSON response:
+
+```bash
+curl -X POST "{{BASE_URL}}/api/generate" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "iconId":"feather-star",
+    "backgroundColor":"#1a1a2e",
+    "iconColor":"#eaf6ff",
+    "size":128
+  }'
+```
+
+Generate raw SVG response:
+
+```bash
+curl -X POST "{{BASE_URL}}/api/generate?format=svg" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "iconId":"feather-star",
+    "backgroundColor":"#1a1a2e",
+    "iconColor":"#eaf6ff",
+    "size":128
+  }'
+```
+
+## Error format
+
+Error responses follow:
+
+```json
+{
+  "error": "error_code",
+  "message": "Human readable message"
+}
+```
+
+Validation errors from `POST /api/generate` also include `details`.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "react-dom": "^19.2.3",
     "react-dropzone": "^14.3.8",
     "remixicon": "^4.7.0",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",

--- a/src/utils/__tests__/icon-catalog-server.test.ts
+++ b/src/utils/__tests__/icon-catalog-server.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearIconCatalogServerCache,
+  getIconByIdServer,
+  getIconPacksServer,
+  getRemixIconCategoriesServer,
+  loadIconCatalogServer,
+  searchIconsServer,
+} from "../icon-catalog-server";
+import type { IconCatalog } from "@/src/types/icon";
+
+const { readFileMock } = vi.hoisted(() => ({
+  readFileMock: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: readFileMock,
+  default: {
+    readFile: readFileMock,
+  },
+}));
+
+const sampleCatalog: IconCatalog = {
+  meta: {
+    version: "test",
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    totalIcons: 3,
+  },
+  licenses: {
+    "zendesk-garden": { name: "Garden", type: "Apache-2.0", url: "#" },
+    feather: { name: "Feather", type: "MIT", url: "#" },
+    remixicon: { name: "RemixIcon", type: "Apache-2.0", url: "#" },
+    emoji: { name: "Emoji", type: "CC0", url: "#" },
+    "custom-svg": { name: "Custom SVG", type: "Custom", url: "#" },
+    "custom-image": { name: "Custom Image", type: "Custom", url: "#" },
+  },
+  icons: {
+    "feather-star": {
+      id: "feather-star",
+      name: "Star",
+      pack: "feather",
+      svg: '<svg viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+      keywords: ["star", "favorite"],
+    },
+    "remixicon-home-line": {
+      id: "remixicon-home-line",
+      name: "Home",
+      pack: "remixicon",
+      svg: '<svg viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+      keywords: ["home"],
+      category: "Buildings",
+    },
+    "remixicon-home-fill": {
+      id: "remixicon-home-fill",
+      name: "Home Fill",
+      pack: "remixicon",
+      svg: '<svg viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+      keywords: ["home", "fill"],
+      category: "Buildings",
+    },
+  },
+  byPack: {
+    "zendesk-garden": [],
+    feather: ["feather-star"],
+    remixicon: ["remixicon-home-line", "remixicon-home-fill"],
+    emoji: [],
+    "custom-svg": [],
+    "custom-image": [],
+  },
+};
+
+describe("icon-catalog-server", () => {
+  beforeEach(() => {
+    clearIconCatalogServerCache();
+    readFileMock.mockReset();
+    readFileMock.mockResolvedValue(JSON.stringify(sampleCatalog));
+  });
+
+  it("loads and caches icon catalog", async () => {
+    const first = await loadIconCatalogServer();
+    const second = await loadIconCatalogServer();
+
+    expect(first.meta.totalIcons).toBe(3);
+    expect(second.meta.version).toBe("test");
+    expect(readFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("searches icons with pack, category, and pagination", async () => {
+    const results = await searchIconsServer({
+      query: "home",
+      pack: "remixicon",
+      category: "Buildings",
+      limit: 1,
+      offset: 1,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe("remixicon-home-fill");
+  });
+
+  it("gets icon by id and returns null when missing", async () => {
+    const icon = await getIconByIdServer("feather-star");
+    const missing = await getIconByIdServer("missing-id");
+
+    expect(icon?.name).toBe("Star");
+    expect(missing).toBeNull();
+  });
+
+  it("returns remix categories and pack counts", async () => {
+    const categories = await getRemixIconCategoriesServer();
+    const packs = await getIconPacksServer();
+
+    expect(categories).toEqual(["Buildings"]);
+    expect(packs.find((pack) => pack.id === "feather")?.count).toBe(1);
+    expect(packs.find((pack) => pack.id === "remixicon")?.count).toBe(2);
+  });
+});

--- a/src/utils/__tests__/renderer-server.test.ts
+++ b/src/utils/__tests__/renderer-server.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { renderSvgServer } from "../renderer-server";
+import type { IconMetadata } from "@/src/types/icon";
+
+function createIcon(svg: string): IconMetadata {
+  return {
+    id: "feather-star",
+    name: "Star",
+    pack: "feather",
+    svg,
+    keywords: ["star"],
+  };
+}
+
+describe("renderer-server", () => {
+  it("renders SVG with solid background and icon color", () => {
+    const icon = createIcon(
+      '<svg viewBox="0 0 24 24"><path fill="currentColor" d="M0 0"/></svg>'
+    );
+
+    const output = renderSvgServer({
+      icon,
+      backgroundColor: "#000000",
+      iconColor: "#ffffff",
+      size: 120,
+    });
+
+    expect(output).toContain('viewBox="0 0 120 120"');
+    expect(output).toContain('fill="#000000"');
+    expect(output).toContain('fill="#ffffff"');
+  });
+
+  it("supports zendesk location mode with transparent background", () => {
+    const icon = createIcon(
+      '<svg viewBox="0 0 24 24"><path fill="currentColor" d="M0 0"/></svg>'
+    );
+
+    const output = renderSvgServer({
+      icon,
+      backgroundColor: "#ff0000",
+      iconColor: "#00ff00",
+      size: 30,
+      zendeskLocationMode: true,
+    });
+
+    expect(output).toContain("currentColor");
+    expect(output).not.toContain('fill="#ff0000"');
+  });
+});

--- a/src/utils/api-docs.ts
+++ b/src/utils/api-docs.ts
@@ -1,0 +1,63 @@
+/**
+ * Utilities for API docs rendering and URL injection.
+ */
+
+const DEFAULT_BASE_URL = "http://localhost:3000";
+const BASE_URL_PLACEHOLDER = "{{BASE_URL}}";
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function normalizeUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    return trimTrailingSlash(parsed.toString());
+  } catch {
+    return null;
+  }
+}
+
+function inferProtocol(
+  host: string,
+  forwardedProto?: string | null
+): "http" | "https" {
+  if (forwardedProto === "http" || forwardedProto === "https") {
+    return forwardedProto;
+  }
+
+  const lowerHost = host.toLowerCase();
+  if (
+    lowerHost.startsWith("localhost") ||
+    lowerHost.startsWith("127.0.0.1") ||
+    lowerHost.endsWith(".local")
+  ) {
+    return "http";
+  }
+
+  return "https";
+}
+
+export function resolveDocsBaseUrl(options?: {
+  host?: string | null;
+  forwardedProto?: string | null;
+}): string {
+  const envUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ?? process.env.API_BASE_URL ?? "";
+  const normalizedEnvUrl = envUrl ? normalizeUrl(envUrl) : null;
+  if (normalizedEnvUrl) {
+    return normalizedEnvUrl;
+  }
+
+  const host = options?.host?.trim();
+  if (host) {
+    const protocol = inferProtocol(host, options?.forwardedProto);
+    return `${protocol}://${host}`;
+  }
+
+  return DEFAULT_BASE_URL;
+}
+
+export function injectDocsBaseUrl(markdown: string, baseUrl: string): string {
+  return markdown.replaceAll(BASE_URL_PLACEHOLDER, trimTrailingSlash(baseUrl));
+}

--- a/src/utils/icon-catalog-server.ts
+++ b/src/utils/icon-catalog-server.ts
@@ -1,0 +1,159 @@
+/**
+ * Server-side icon catalog utilities.
+ *
+ * Reads the generated catalog from disk so API routes can query icon data
+ * without relying on browser `fetch("/icon-catalog.json")`.
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { IconCatalog, IconMetadata, IconPack } from "@/src/types/icon";
+
+export type ApiIconPack = IconPack | "all" | "garden";
+
+export interface SearchIconsOptions {
+  query?: string;
+  pack?: ApiIconPack;
+  category?: string | null;
+  limit?: number;
+  offset?: number;
+}
+
+let catalogCache: IconCatalog | null = null;
+let searchIndexCache: Array<{ icon: IconMetadata; searchText: string }> | null =
+  null;
+
+const UI_PACK_MAP: Record<string, IconPack> = {
+  garden: "zendesk-garden",
+  feather: "feather",
+  remixicon: "remixicon",
+  emoji: "emoji",
+  "custom-svg": "custom-svg",
+  "custom-image": "custom-image",
+};
+
+function getCatalogPath(): string {
+  return path.join(process.cwd(), "public", "icon-catalog.json");
+}
+
+function normalizePack(pack?: ApiIconPack): IconPack | "all" {
+  if (!pack || pack === "all") {
+    return "all";
+  }
+
+  return UI_PACK_MAP[pack] ?? pack;
+}
+
+function buildSearchIndex(catalog: IconCatalog) {
+  if (searchIndexCache) {
+    return searchIndexCache;
+  }
+
+  searchIndexCache = Object.values(catalog.icons).map((icon) => {
+    const searchText = `${icon.name} ${icon.id} ${icon.keywords.join(" ")} ${
+      icon.category ?? ""
+    }`.toLowerCase();
+
+    return {
+      icon,
+      searchText,
+    };
+  });
+
+  return searchIndexCache;
+}
+
+export async function loadIconCatalogServer(): Promise<IconCatalog> {
+  if (catalogCache) {
+    return catalogCache;
+  }
+
+  const filePath = getCatalogPath();
+  const raw = await readFile(filePath, "utf-8");
+  const catalog = JSON.parse(raw) as IconCatalog;
+  catalogCache = catalog;
+  searchIndexCache = null;
+  return catalog;
+}
+
+export async function getIconByIdServer(
+  id: string
+): Promise<IconMetadata | null> {
+  const catalog = await loadIconCatalogServer();
+  return catalog.icons[id] ?? null;
+}
+
+export async function searchIconsServer(
+  options: SearchIconsOptions
+): Promise<IconMetadata[]> {
+  const catalog = await loadIconCatalogServer();
+  const {
+    query = "",
+    pack = "all",
+    category = null,
+    limit = 50,
+    offset = 0,
+  } = options;
+
+  const trimmedQuery = query.trim().toLowerCase();
+  const normalizedPack = normalizePack(pack);
+  const normalizedCategory = category?.trim() || null;
+
+  const searched =
+    trimmedQuery.length === 0
+      ? Object.values(catalog.icons)
+      : buildSearchIndex(catalog)
+          .filter(({ searchText }) => searchText.includes(trimmedQuery))
+          .map(({ icon }) => icon);
+
+  const byPack =
+    normalizedPack === "all"
+      ? searched
+      : searched.filter((icon) => icon.pack === normalizedPack);
+
+  const byCategory = normalizedCategory
+    ? byPack.filter((icon) => icon.category === normalizedCategory)
+    : byPack;
+
+  const safeOffset = Math.max(0, offset);
+  const safeLimit = Math.min(Math.max(1, limit), 250);
+  return byCategory.slice(safeOffset, safeOffset + safeLimit);
+}
+
+export async function getRemixIconCategoriesServer(): Promise<string[]> {
+  const catalog = await loadIconCatalogServer();
+  const remixIds = catalog.byPack.remixicon ?? [];
+  const categories = new Set<string>();
+
+  for (const id of remixIds) {
+    const icon = catalog.icons[id];
+    if (icon?.category) {
+      categories.add(icon.category);
+    }
+  }
+
+  return Array.from(categories).sort();
+}
+
+export async function getIconPacksServer(): Promise<
+  Array<{
+    id: IconPack;
+    count: number;
+    license: IconCatalog["licenses"][IconPack];
+  }>
+> {
+  const catalog = await loadIconCatalogServer();
+
+  return (Object.keys(catalog.byPack) as IconPack[])
+    .sort()
+    .map((pack) => ({
+      id: pack,
+      count: catalog.byPack[pack]?.length ?? 0,
+      license: catalog.licenses[pack],
+    }));
+}
+
+export function clearIconCatalogServerCache(): void {
+  catalogCache = null;
+  searchIndexCache = null;
+}

--- a/src/utils/renderer-server.ts
+++ b/src/utils/renderer-server.ts
@@ -1,0 +1,231 @@
+/**
+ * Server-safe SVG renderer.
+ *
+ * This version intentionally avoids DOM-dependent measurements (getBBox) and
+ * uses viewBox-based centering, which is stable in Node.js API routes.
+ */
+
+import type { IconMetadata } from "@/src/types/icon";
+import type { BackgroundValue } from "@/src/utils/gradients";
+import { gradientToSvgDef, isGradient } from "@/src/utils/gradients";
+import { applySvgColor } from "@/src/utils/renderer";
+
+export interface ServerSvgRenderOptions {
+  icon: IconMetadata;
+  backgroundColor: BackgroundValue;
+  iconColor: string;
+  size: number;
+  padding?: number;
+  outputSize?: number;
+  zendeskLocationMode?: boolean;
+}
+
+function isRasterizedSvg(content: string): boolean {
+  return /<image[^>]*>/i.test(content);
+}
+
+function parseSvg(svgString: string): {
+  viewBox: string;
+  content: string;
+  inheritedFill?: string;
+  inheritedStroke?: string;
+  inheritedStrokeWidth?: string;
+  inheritedStrokeLinecap?: string;
+  inheritedStrokeLinejoin?: string;
+  isRasterized?: boolean;
+} {
+  const svgMatch = svgString.match(/<svg[^>]*>([\s\S]*)<\/svg>/i);
+  if (!svgMatch) {
+    throw new Error("Invalid SVG format");
+  }
+
+  const svgTag = svgString.match(/<svg[^>]*>/i)?.[0] ?? "";
+
+  let viewBox = "0 0 24 24";
+  const viewBoxMatch = svgTag.match(/viewBox=["']([^"']+)["']/i);
+  if (viewBoxMatch) {
+    viewBox = viewBoxMatch[1];
+  } else {
+    const widthMatch = svgTag.match(/width=["']([^"']+)["']/i);
+    const heightMatch = svgTag.match(/height=["']([^"']+)["']/i);
+    if (widthMatch && heightMatch) {
+      const width = parseFloat(widthMatch[1]) || 24;
+      const height = parseFloat(heightMatch[1]) || 24;
+      viewBox = `0 0 ${width} ${height}`;
+    }
+  }
+
+  const fillMatch = svgTag.match(/fill=["']([^"']*)["']/i);
+  const strokeMatch = svgTag.match(/stroke=["']([^"']*)["']/i);
+  const strokeWidthMatch = svgTag.match(/stroke-width=["']([^"']*)["']/i);
+  const strokeLinecapMatch = svgTag.match(/stroke-linecap=["']([^"']*)["']/i);
+  const strokeLinejoinMatch = svgTag.match(/stroke-linejoin=["']([^"']*)["']/i);
+
+  const inheritedFill = fillMatch ? fillMatch[1] : undefined;
+  const inheritedStroke = strokeMatch ? strokeMatch[1] : undefined;
+  const inheritedStrokeWidth = strokeWidthMatch ? strokeWidthMatch[1] : undefined;
+  const inheritedStrokeLinecap = strokeLinecapMatch
+    ? strokeLinecapMatch[1]
+    : undefined;
+  const inheritedStrokeLinejoin = strokeLinejoinMatch
+    ? strokeLinejoinMatch[1]
+    : undefined;
+
+  const content = svgMatch[1];
+  const isRasterized = isRasterizedSvg(content);
+
+  return {
+    viewBox,
+    content,
+    inheritedFill,
+    inheritedStroke,
+    inheritedStrokeWidth,
+    inheritedStrokeLinecap,
+    inheritedStrokeLinejoin,
+    isRasterized,
+  };
+}
+
+export function renderSvgServer(options: ServerSvgRenderOptions): string {
+  const {
+    icon,
+    backgroundColor,
+    iconColor,
+    size,
+    padding = 0,
+    outputSize,
+    zendeskLocationMode = false,
+  } = options;
+
+  const {
+    viewBox,
+    content,
+    inheritedFill,
+    inheritedStroke,
+    inheritedStrokeWidth,
+    inheritedStrokeLinecap,
+    inheritedStrokeLinejoin,
+    isRasterized,
+  } = parseSvg(icon.svg);
+
+  const shouldSkipColorTransform =
+    zendeskLocationMode ||
+    isRasterized ||
+    icon.isRasterized ||
+    icon.allowColorOverride === false;
+  const coloredContent = shouldSkipColorTransform
+    ? content
+    : applySvgColor(content, iconColor);
+
+  const effectivePadding = Math.min(padding, size / 2);
+  const iconSize = size - effectivePadding * 2;
+  const viewBoxParts = viewBox.split(/\s+/).map(Number);
+  const vbMinX = viewBoxParts[0] || 0;
+  const vbMinY = viewBoxParts[1] || 0;
+  const vbWidth = viewBoxParts[2] || 24;
+  const vbHeight = viewBoxParts[3] || 24;
+
+  let backgroundElement = "";
+  let gradientDef = "";
+
+  if (!zendeskLocationMode) {
+    if (isGradient(backgroundColor)) {
+      const gradientId = `bg-gradient-${Math.random().toString(36).slice(2, 11)}`;
+      gradientDef = gradientToSvgDef(backgroundColor, gradientId, size);
+      backgroundElement = `<rect width="${size}" height="${size}" fill="url(#${gradientId})"/>`;
+    } else {
+      backgroundElement = `<rect width="${size}" height="${size}" fill="${backgroundColor}"/>`;
+    }
+  }
+
+  if (shouldSkipColorTransform) {
+    const imageMatch = content.match(/<image[^>]*>/i);
+    if (imageMatch) {
+      const imageTag = imageMatch[0];
+      const hrefMatch =
+        imageTag.match(/href=["']([^"']+)["']/i) ||
+        imageTag.match(/xlink:href=["']([^"']+)["']/i);
+      const widthMatch = imageTag.match(/width=["']([^"']+)["']/i);
+      const heightMatch = imageTag.match(/height=["']([^"']+)["']/i);
+
+      const href = hrefMatch ? hrefMatch[1] : "";
+      const imgWidth = widthMatch ? parseFloat(widthMatch[1]) : vbWidth;
+      const imgHeight = heightMatch ? parseFloat(heightMatch[1]) : vbHeight;
+
+      const scale = iconSize / Math.max(imgWidth, imgHeight);
+      const scaledWidth = imgWidth * scale;
+      const scaledHeight = imgHeight * scale;
+      const iconX = effectivePadding + (iconSize - scaledWidth) / 2;
+      const iconY = effectivePadding + (iconSize - scaledHeight) / 2;
+      const finalSize = outputSize ?? size;
+
+      const rasterBgElements = backgroundElement
+        ? `${gradientDef ? `${gradientDef}\n` : ""}  ${backgroundElement}\n`
+        : "";
+
+      return `<svg width="${finalSize}" height="${finalSize}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+${rasterBgElements}  <image href="${href}" width="${scaledWidth}" height="${scaledHeight}" x="${iconX}" y="${iconY}"/>
+</svg>`;
+    }
+  }
+
+  const scale = iconSize / Math.max(vbWidth, vbHeight);
+  const baseIconX = effectivePadding + (iconSize - vbWidth * scale) / 2;
+  const baseIconY = effectivePadding + (iconSize - vbHeight * scale) / 2;
+  const needsViewBoxOffset = vbMinX !== 0 || vbMinY !== 0;
+
+  const groupAttrs: string[] = [];
+
+  if (inheritedFill !== undefined) {
+    const fillValue = inheritedFill.toLowerCase().trim();
+    if (fillValue === "none") {
+      groupAttrs.push('fill="none"');
+    } else if (fillValue === "currentcolor" || fillValue === "current-color") {
+      groupAttrs.push(
+        zendeskLocationMode ? 'fill="currentColor"' : `fill="${iconColor}"`
+      );
+    }
+  }
+
+  if (
+    inheritedStroke !== undefined &&
+    inheritedStroke.toLowerCase().trim() === "currentcolor"
+  ) {
+    groupAttrs.push(
+      zendeskLocationMode ? 'stroke="currentColor"' : `stroke="${iconColor}"`
+    );
+  }
+
+  if (inheritedStrokeWidth !== undefined) {
+    groupAttrs.push(`stroke-width="${inheritedStrokeWidth}"`);
+  }
+  if (inheritedStrokeLinecap !== undefined) {
+    groupAttrs.push(`stroke-linecap="${inheritedStrokeLinecap}"`);
+  }
+  if (inheritedStrokeLinejoin !== undefined) {
+    groupAttrs.push(`stroke-linejoin="${inheritedStrokeLinejoin}"`);
+  }
+
+  const groupAttrString =
+    groupAttrs.length > 0 ? ` ${groupAttrs.join(" ")}` : "";
+
+  const transformParts: string[] = [
+    `translate(${baseIconX}, ${baseIconY})`,
+    `scale(${scale})`,
+  ];
+  if (needsViewBoxOffset) {
+    transformParts.push(`translate(${-vbMinX}, ${-vbMinY})`);
+  }
+  const combinedTransform = transformParts.join(" ");
+
+  const finalSize = outputSize ?? size;
+  const bgElements = backgroundElement
+    ? `${gradientDef ? `${gradientDef}\n` : ""}  ${backgroundElement}\n`
+    : "";
+
+  return `<svg width="${finalSize}" height="${finalSize}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
+${bgElements}  <g transform="${combinedTransform}"${groupAttrString}>
+    ${coloredContent}
+  </g>
+</svg>`;
+}


### PR DESCRIPTION
## Summary
- add Node-based API routes for icon discovery (`/api/icons*`), config lookups, and SVG generation (`POST /api/generate`) tailored to AI-agent workflows
- add server-side catalog/renderer utilities plus route/unit tests, and document usage in `docs/api-reference.md`
- add docs surfaces at `/api-docs` and `/api-docs.md` with dynamic base URL injection and expose the docs link in the top navigation

Closes #49

## Test plan
- [x] `bun run verify`
- [x] call local API routes (`/api/icons`, `/api/icons/[id]`, `/api/generate`)
- [x] open `/api-docs` and `/api-docs.md` and verify base URL resolution

Made with [Cursor](https://cursor.com)