### PR TITLE
feat: improve API docs navigation and agent prompt UX

### DIFF
--- a/app/api-docs/CopyAgentPromptButton.tsx
+++ b/app/api-docs/CopyAgentPromptButton.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import * as React from "react";
+import { Check, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface CopyAgentPromptButtonProps {
+  baseUrl: string;
+  docsUrl: string;
+}
+
+function buildPrompt(baseUrl: string, docsUrl: string): string {
+  return [
+    "Use the Icon Generator API to search icons and generate SVG assets.",
+    `Base URL: ${baseUrl}`,
+    `Full API reference (raw markdown): ${docsUrl}`,
+    "",
+    "Suggested flow:",
+    "1) Search icons — GET /api/icons?q=<query>",
+    "2) Get icon details — GET /api/icons/<id>",
+    "3) Generate SVG — POST /api/generate",
+    "",
+    "Read the docs URL above for request/response schemas and examples.",
+  ].join("\n");
+}
+
+export function CopyAgentPromptButton({
+  baseUrl,
+  docsUrl,
+}: CopyAgentPromptButtonProps) {
+  const [status, setStatus] = React.useState<"idle" | "copied" | "error">(
+    "idle"
+  );
+
+  const copyToClipboard = React.useCallback(async () => {
+    const text = buildPrompt(baseUrl, docsUrl);
+
+    try {
+      await navigator.clipboard.writeText(text);
+      setStatus("copied");
+    } catch {
+      setStatus("error");
+    }
+
+    window.setTimeout(() => setStatus("idle"), 2200);
+  }, [baseUrl, docsUrl]);
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={copyToClipboard}
+      aria-label="Copy base agent prompt"
+      title="Copy base agent prompt"
+    >
+      {status === "copied" ? (
+        <>
+          <Check className="h-4 w-4" />
+          Copied
+        </>
+      ) : status === "error" ? (
+        "Copy failed"
+      ) : (
+        <>
+          <Copy className="h-4 w-4" />
+          Copy agent prompt
+        </>
+      )}
+    </Button>
+  );
+}

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -3,7 +3,10 @@ import Link from "next/link";
 import { headers } from "next/headers";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { ArrowLeft, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { injectDocsBaseUrl, resolveDocsBaseUrl } from "@/src/utils/api-docs";
+import { CopyAgentPromptButton } from "./CopyAgentPromptButton";
 
 export const metadata: Metadata = {
   title: "API Docs",
@@ -22,58 +25,80 @@ export default async function ApiDocsPage() {
     host: requestHeaders.get("x-forwarded-host") ?? requestHeaders.get("host"),
     forwardedProto: requestHeaders.get("x-forwarded-proto"),
   });
+  const docsUrl = `${baseUrl}/api-docs.md`;
   const resolvedMarkdown = injectDocsBaseUrl(markdown, baseUrl);
 
   return (
-    <main className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto w-full max-w-5xl px-6 py-10">
-        <div className="mb-6 flex items-center justify-between gap-4">
-          <h1 className="text-3xl font-semibold">Icon Generator API Docs</h1>
-          <Link
-            href="/api-docs.md"
-            className="rounded border px-3 py-2 text-sm hover:bg-muted"
-          >
-            View raw markdown
-          </Link>
-        </div>
-
-        <section className="mb-6 rounded-lg border bg-muted/30 p-5">
-          <h2 className="text-xl font-semibold">What this API is for</h2>
-          <p className="mt-2 text-sm text-muted-foreground">
-            This API gives AI agents and scripts a predictable way to discover
-            icons, configure style options, and generate final SVG assets that
-            can be transformed into PNG/ICO externally.
-          </p>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Active base URL: <code>{baseUrl}</code>
-          </p>
-          <div className="mt-4 grid gap-3 text-sm md:grid-cols-3">
-            <div className="rounded-md border bg-background p-3">
-              <p className="font-medium">Discover</p>
-              <p className="mt-1 text-muted-foreground">
-                Search icons, list packs/categories, and inspect icon metadata.
-              </p>
-            </div>
-            <div className="rounded-md border bg-background p-3">
-              <p className="font-medium">Generate</p>
-              <p className="mt-1 text-muted-foreground">
-                Produce SVG with solid/gradient backgrounds, color, and scale
-                controls.
-              </p>
-            </div>
-            <div className="rounded-md border bg-background p-3">
-              <p className="font-medium">Integrate</p>
-              <p className="mt-1 text-muted-foreground">
-                Use HTTP, curl, or agent workflows; consume JSON or raw SVG.
-              </p>
-            </div>
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <header className="border-b bg-background px-6 py-4">
+        <div className="mx-auto flex w-full max-w-5xl items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/">
+                <ArrowLeft className="h-4 w-4" />
+                Back to Generator
+              </Link>
+            </Button>
+            <span className="text-muted-foreground">|</span>
+            <h1 className="text-lg font-semibold">API Docs</h1>
           </div>
-        </section>
 
-        <pre className="overflow-x-auto rounded-lg border bg-muted p-5 text-sm leading-6 whitespace-pre-wrap">
-          {resolvedMarkdown}
-        </pre>
-      </div>
-    </main>
+          <div className="flex items-center gap-2">
+            <CopyAgentPromptButton baseUrl={baseUrl} docsUrl={docsUrl} />
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/api-docs.md">
+                <FileText className="h-4 w-4" />
+                Raw markdown
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1">
+        <div className="mx-auto w-full max-w-5xl px-6 py-8">
+          <section className="mb-8 rounded-lg border bg-muted/30 p-6">
+            <h2 className="text-xl font-semibold">
+              Icon Generator API for AI Agents
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+              Use this API to search thousands of icons, pick colors and
+              gradients, and generate production-ready SVG assets from any
+              script, CLI, or AI agent. Convert SVGs to PNG/ICO externally with
+              your preferred tooling.
+            </p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Base URL: <code className="text-foreground">{baseUrl}</code>
+            </p>
+            <div className="mt-5 grid gap-3 text-sm md:grid-cols-3">
+              <div className="rounded-md border bg-background p-3">
+                <p className="font-medium">Discover</p>
+                <p className="mt-1 text-muted-foreground">
+                  Search icons, list packs/categories, and inspect icon
+                  metadata.
+                </p>
+              </div>
+              <div className="rounded-md border bg-background p-3">
+                <p className="font-medium">Generate</p>
+                <p className="mt-1 text-muted-foreground">
+                  Produce SVG with solid/gradient backgrounds, color, and scale
+                  controls.
+                </p>
+              </div>
+              <div className="rounded-md border bg-background p-3">
+                <p className="font-medium">Integrate</p>
+                <p className="mt-1 text-muted-foreground">
+                  Use HTTP, curl, or agent workflows; consume JSON or raw SVG.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <pre className="overflow-x-auto rounded-lg border bg-muted p-6 text-sm leading-6 whitespace-pre-wrap">
+            {resolvedMarkdown}
+          </pre>
+        </div>
+      </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a top header to `/api-docs` with a clear back-to-generator action
- add a dedicated `Copy agent prompt` button to make agent onboarding faster
- ensure the copied prompt points to the raw markdown docs URL (`/api-docs.md`)

## Test plan
- [x] Run `bun run lint`
- [x] Open `/api-docs` and verify Back to Generator navigation
- [x] Click Copy agent prompt and confirm copied text includes `/api-docs.md`

Made with [Cursor](https://cursor.com)