### PR TITLE
feat: add icon-bundle-generator skill for skills.sh

### DIFF
--- a/.agents/skills/icon-bundle-generator/SKILL.md
+++ b/.agents/skills/icon-bundle-generator/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: icon-bundle-generator
+description: Generate SVG icons with Bundle Icon Generator and produce platform icon bundles from SVG input. Use when users ask for icon bundle exports like favicon, macOS app icons, PWA icons, social assets, or preset-aligned generation.
+---
+
+# Icon Bundle Generator
+
+Use this skill to generate icon assets from the service and convert generated SVG output into preset-aligned platform bundles.
+
+## When to Use
+
+- User asks to generate icons using API endpoints.
+- User references `docs/api-reference.md` or endpoint names like `/api/icons` or `/api/generate`.
+- User asks for asset bundles (favicon, macOS app icon, PWA, social media, Raycast, Zendesk PNG-only).
+
+## Required Inputs
+
+- Default API host: `https://bundle-icon-generator.vercel.app`
+- Icon/style inputs:
+  - `iconId` or icon search query.
+  - `backgroundColor` (hex or gradient object).
+  - `iconColor` (hex).
+  - Optional sizing: `size`, `padding`, `outputSize`.
+
+## Workflow
+
+1. Discover icon candidates with `GET /api/icons`.
+2. Confirm the chosen icon with `GET /api/icons/[id]`.
+3. Generate SVG via `POST /api/generate`.
+4. Save SVG to disk (for example `output/icon.svg`).
+5. If bundle assets are requested, run `scripts/generate-bundle-assets.py`.
+
+Detailed endpoint formats and payloads are in [references/api-reference.md](references/api-reference.md).
+
+## Auto-Run Rules
+
+When users request bundle exports from SVG, run:
+
+```bash
+python3 scripts/generate-bundle-assets.py --input-svg <svg-path> --output-dir <output-dir> --preset <preset-id>
+```
+
+Supported preset IDs (parity with app export presets where SVG-to-raster conversion applies):
+
+- `favicon-bundle`
+- `pwa-icons`
+- `macos-app-icon`
+- `raycast-extension`
+- `social-media`
+- `zendesk-png-only`
+- `single-png`
+- `single-svg`
+
+For macOS, generate `.icns` in addition to icon PNGs:
+
+```bash
+python3 scripts/generate-bundle-assets.py --input-svg <svg-path> --preset macos-app-icon --create-icns
+```
+
+For favicon/browser app assets, use the `favicon-bundle` preset.
+
+If dependencies are missing, install:
+
+```bash
+python3 -m pip install cairosvg pillow
+```
+
+## Error Handling
+
+- API errors return:
+  - `error` (machine code)
+  - `message` (human description)
+- Validation failures from `POST /api/generate` can include `details`; surface these fields directly to the user and suggest corrected payload values.
+
+## Examples
+
+Generate SVG:
+
+```bash
+curl -X POST "https://bundle-icon-generator.vercel.app/api/generate?format=svg" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "iconId":"feather-star",
+    "backgroundColor":"#1a1a2e",
+    "iconColor":"#eaf6ff",
+    "size":128
+  }'
+```
+
+Generate macOS bundle from saved SVG:
+
+```bash
+python3 scripts/generate-bundle-assets.py \
+  --input-svg output/icon.svg \
+  --output-dir output/bundles \
+  --preset macos-app-icon \
+  --create-icns
+```

--- a/.agents/skills/icon-bundle-generator/references/api-reference.md
+++ b/.agents/skills/icon-bundle-generator/references/api-reference.md
@@ -1,0 +1,168 @@
+# Bundle Icon Generator API Reference
+
+This API supports agent-driven icon workflows.
+
+- Base URL: `https://bundle-icon-generator.vercel.app`
+- Output focus: SVG generation
+- Typical flow:
+  1. Search icon
+  2. Read icon metadata
+  3. Generate SVG
+  4. Convert SVG to PNG/ICO/ICNS externally
+
+## Endpoints
+
+### `GET /api/icons`
+
+Search and filter icons.
+
+Query params:
+
+- `q` (optional): search text
+- `pack` (optional): `all`, `garden`, `zendesk-garden`, `feather`, `remixicon`, `emoji`, `custom-svg`, `custom-image`
+- `category` (optional): category name (mainly RemixIcon)
+- `limit` (optional, default `50`, max `250`)
+- `offset` (optional, default `0`)
+
+Example:
+
+```bash
+curl "https://bundle-icon-generator.vercel.app/api/icons?q=star&pack=feather&limit=5"
+```
+
+### `GET /api/icons/[id]`
+
+Returns icon metadata and source SVG.
+
+```bash
+curl "https://bundle-icon-generator.vercel.app/api/icons/feather-star"
+```
+
+### `GET /api/icons/packs`
+
+List packs, counts, and license metadata.
+
+```bash
+curl "https://bundle-icon-generator.vercel.app/api/icons/packs"
+```
+
+### `GET /api/icons/categories`
+
+List RemixIcon categories.
+
+```bash
+curl "https://bundle-icon-generator.vercel.app/api/icons/categories"
+```
+
+### `GET /api/config/gradients`
+
+List gradient presets and values.
+
+```bash
+curl "https://bundle-icon-generator.vercel.app/api/config/gradients"
+```
+
+### `GET /api/config/locations`
+
+List Zendesk app locations and location mode rules.
+
+```bash
+curl "https://bundle-icon-generator.vercel.app/api/config/locations"
+```
+
+### `POST /api/generate`
+
+Generate an SVG icon from icon id and style options.
+
+Request body example:
+
+```json
+{
+  "iconId": "feather-star",
+  "backgroundColor": "#063940",
+  "iconColor": "#ffffff",
+  "size": 128,
+  "padding": 8,
+  "outputSize": 128,
+  "zendeskLocationMode": false,
+  "filename": "logo.svg"
+}
+```
+
+Rules:
+
+- `iconId`: required string
+- `backgroundColor`: `#RRGGBB` or gradient object
+- `iconColor`: `#RRGGBB`
+- `size`: integer `48..300`
+- `padding`: optional `-200..200` (default `8`)
+- `outputSize`: optional integer `16..4096`
+- `zendeskLocationMode`: optional boolean
+
+Linear gradient example:
+
+```json
+{
+  "type": "linear",
+  "angle": 135,
+  "stops": [
+    { "color": "#667eea", "offset": 0 },
+    { "color": "#764ba2", "offset": 100 }
+  ]
+}
+```
+
+Radial gradient example:
+
+```json
+{
+  "type": "radial",
+  "centerX": 50,
+  "centerY": 50,
+  "radius": 70,
+  "stops": [
+    { "color": "#ff0080", "offset": 0 },
+    { "color": "#7928ca", "offset": 100 }
+  ]
+}
+```
+
+Generate JSON response:
+
+```bash
+curl -X POST "https://bundle-icon-generator.vercel.app/api/generate" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "iconId":"feather-star",
+    "backgroundColor":"#1a1a2e",
+    "iconColor":"#eaf6ff",
+    "size":128
+  }'
+```
+
+Generate raw SVG response:
+
+```bash
+curl -X POST "https://bundle-icon-generator.vercel.app/api/generate?format=svg" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "iconId":"feather-star",
+    "backgroundColor":"#1a1a2e",
+    "iconColor":"#eaf6ff",
+    "size":128
+  }'
+```
+
+## Error Format
+
+Error response shape:
+
+```json
+{
+  "error": "error_code",
+  "message": "Human readable message"
+}
+```
+
+Validation failures from `POST /api/generate` may include an additional `details` field.

--- a/.agents/skills/icon-bundle-generator/scripts/generate-bundle-assets.py
+++ b/.agents/skills/icon-bundle-generator/scripts/generate-bundle-assets.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+# pyright: reportMissingImports=false
+"""
+Generate preset-aligned icon bundles from a source SVG.
+
+Supported presets (aligned with app export presets where SVG-to-raster applies):
+- favicon-bundle
+- pwa-icons
+- macos-app-icon
+- raycast-extension
+- social-media
+- zendesk-png-only
+- single-png
+- single-svg
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+PNG_PRESET_SPECS: dict[str, dict[str, tuple[int, int]]] = {
+    "favicon-bundle": {
+        "favicon-16x16.png": (16, 16),
+        "favicon-32x32.png": (32, 32),
+        "apple-touch-icon.png": (180, 180),
+        "android-chrome-192x192.png": (192, 192),
+        "android-chrome-512x512.png": (512, 512),
+    },
+    "pwa-icons": {
+        "icon-192x192.png": (192, 192),
+        "icon-512x512.png": (512, 512),
+        "icon-144x144.png": (144, 144),
+        "icon-384x384.png": (384, 384),
+    },
+    "macos-app-icon": {
+        "icon_16x16.png": (16, 16),
+        "icon_16x16@2x.png": (32, 32),
+        "icon_32x32.png": (32, 32),
+        "icon_32x32@2x.png": (64, 64),
+        "icon_128x128.png": (128, 128),
+        "icon_128x128@2x.png": (256, 256),
+        "icon_256x256.png": (256, 256),
+        "icon_256x256@2x.png": (512, 512),
+        "icon_512x512.png": (512, 512),
+        "icon_512x512@2x.png": (1024, 1024),
+    },
+    "raycast-extension": {
+        "icon.png": (512, 512),
+    },
+    "social-media": {
+        "og-image.png": (1200, 630),
+        "twitter-card.png": (1200, 600),
+        "profile-400.png": (400, 400),
+        "profile-200.png": (200, 200),
+    },
+    "zendesk-png-only": {
+        "logo.png": (320, 320),
+        "logo-small.png": (128, 128),
+    },
+    "single-png": {
+        "icon.png": (512, 512),
+    },
+}
+
+ALL_PRESETS: tuple[str, ...] = (
+    "favicon-bundle",
+    "pwa-icons",
+    "macos-app-icon",
+    "raycast-extension",
+    "social-media",
+    "zendesk-png-only",
+    "single-png",
+    "single-svg",
+)
+
+
+def parse_sizes(value: str) -> list[int]:
+    parts = [part.strip() for part in value.split(",") if part.strip()]
+    if not parts:
+        raise argparse.ArgumentTypeError("ICO sizes cannot be empty.")
+
+    sizes: list[int] = []
+    for part in parts:
+        if not part.isdigit():
+            raise argparse.ArgumentTypeError(
+                f"Invalid ICO size '{part}'. Use comma-separated integers."
+            )
+        size = int(part)
+        if size < 16 or size > 512:
+            raise argparse.ArgumentTypeError(
+                f"Invalid ICO size '{size}'. Expected range: 16..512."
+            )
+        sizes.append(size)
+
+    return sorted(set(sizes))
+
+
+def ensure_dependencies() -> tuple[object, object]:
+    try:
+        import cairosvg
+    except ImportError as exc:
+        raise SystemExit(
+            "Missing dependency: cairosvg\n"
+            "Install with: python3 -m pip install cairosvg"
+        ) from exc
+
+    try:
+        from PIL import Image
+    except ImportError as exc:
+        raise SystemExit(
+            "Missing dependency: Pillow\n"
+            "Install with: python3 -m pip install pillow"
+        ) from exc
+
+    return cairosvg, Image
+
+
+def render_png(
+    cairosvg: object, svg_bytes: bytes, width: int, height: int, output_path: Path
+) -> bytes:
+    png_bytes = cairosvg.svg2png(
+        bytestring=svg_bytes,
+        output_width=width,
+        output_height=height,
+    )
+    output_path.write_bytes(png_bytes)
+    return png_bytes
+
+
+def write_ico(
+    Image: object,
+    cairosvg: object,
+    svg_bytes: bytes,
+    ico_path: Path,
+    ico_sizes: list[int],
+    rendered: dict[int, bytes],
+) -> None:
+    largest_size = max(max(ico_sizes), 512)
+    largest_png = rendered.get(largest_size)
+    if largest_png is None:
+        largest_png = cairosvg.svg2png(
+            bytestring=svg_bytes,
+            output_width=largest_size,
+            output_height=largest_size,
+        )
+
+    source_image = Image.open(io.BytesIO(largest_png)).convert("RGBA")
+    source_image.save(
+        ico_path,
+        format="ICO",
+        sizes=[(size, size) for size in ico_sizes],
+    )
+
+
+def write_icns_if_requested(
+    bundle_dir: Path, rendered_files: dict[str, Path], create_icns: bool
+) -> None:
+    if not create_icns:
+        return
+
+    iconset_dir = bundle_dir / "icon.iconset"
+    iconset_dir.mkdir(parents=True, exist_ok=True)
+
+    for filename, src_path in rendered_files.items():
+        shutil.copyfile(src_path, iconset_dir / filename)
+
+    icns_path = bundle_dir / "icon.icns"
+
+    try:
+        subprocess.run(
+            [
+                "iconutil",
+                "-c",
+                "icns",
+                str(iconset_dir),
+                "-o",
+                str(icns_path),
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        return
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
+
+    # Fallback for non-macOS environments: try Pillow ICNS writer.
+    try:
+        from PIL import Image
+
+        source = Image.open(rendered_files["icon_512x512@2x.png"]).convert("RGBA")
+        source.save(icns_path, format="ICNS")
+    except Exception as exc:  # pragma: no cover - best-effort conversion
+        print(
+            "Warning: unable to generate icon.icns automatically. "
+            f"Generated icon.iconset only. ({exc})"
+        )
+
+
+def generate_bundle(
+    input_svg: Path,
+    output_dir: Path,
+    preset: str,
+    ico_sizes: list[int],
+    create_icns: bool,
+) -> None:
+    if not input_svg.exists():
+        raise SystemExit(f"Input SVG not found: {input_svg}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    bundle_dir = output_dir / preset
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    if preset == "single-svg":
+        shutil.copyfile(input_svg, bundle_dir / "icon.svg")
+        print(f"Generated preset bundle: {preset}")
+        print(f"- Source: {input_svg}")
+        print(f"- Output: {bundle_dir}")
+        return
+
+    cairosvg, Image = ensure_dependencies()
+    svg_bytes = input_svg.read_bytes()
+
+    rendered_bytes: dict[int, bytes] = {}
+    rendered_paths: dict[str, Path] = {}
+
+    for filename, (width, height) in PNG_PRESET_SPECS[preset].items():
+        output_path = bundle_dir / filename
+        rendered_bytes[max(width, height)] = render_png(
+            cairosvg, svg_bytes, width, height, output_path
+        )
+        rendered_paths[filename] = output_path
+
+    if preset == "favicon-bundle":
+        shutil.copyfile(input_svg, bundle_dir / "favicon.svg")
+        write_ico(
+            Image=Image,
+            cairosvg=cairosvg,
+            svg_bytes=svg_bytes,
+            ico_path=bundle_dir / "favicon.ico",
+            ico_sizes=ico_sizes,
+            rendered=rendered_bytes,
+        )
+
+    if preset == "macos-app-icon":
+        write_icns_if_requested(
+            bundle_dir=bundle_dir,
+            rendered_files=rendered_paths,
+            create_icns=create_icns,
+        )
+
+    print(f"Generated preset bundle: {preset}")
+    print(f"- Source: {input_svg}")
+    print(f"- Output: {bundle_dir}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate preset-aligned icon bundles from an SVG source."
+    )
+    parser.add_argument(
+        "--input-svg",
+        type=Path,
+        required=True,
+        help="Path to source SVG file.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("output/bundles"),
+        help="Directory where bundle folders are written.",
+    )
+    parser.add_argument(
+        "--preset",
+        action="append",
+        choices=ALL_PRESETS,
+        help="Preset to generate. Can be provided multiple times.",
+    )
+    parser.add_argument(
+        "--all-presets",
+        action="store_true",
+        help="Generate all supported presets.",
+    )
+    parser.add_argument(
+        "--ico-sizes",
+        type=parse_sizes,
+        default=parse_sizes("16,32,48"),
+        help="Comma-separated ICO sizes for favicon bundle.",
+    )
+    parser.add_argument(
+        "--create-icns",
+        action="store_true",
+        help="For macOS preset, also create icon.icns (best effort on non-macOS).",
+    )
+
+    args = parser.parse_args()
+
+    selected_presets: list[str]
+    if args.all_presets:
+        selected_presets = list(ALL_PRESETS)
+    elif args.preset:
+        selected_presets = args.preset
+    else:
+        raise SystemExit("Provide --preset or --all-presets.")
+
+    for preset in selected_presets:
+        generate_bundle(
+            input_svg=args.input_svg,
+            output_dir=args.output_dir,
+            preset=preset,
+            ico_sizes=args.ico_sizes,
+            create_icns=args.create_icns,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/README.md
+++ b/README.md
@@ -80,6 +80,33 @@ bun run lint            # Run ESLint
 
 The `generate-icons` script processes icons from installed icon packs and generates a unified catalog at `public/icon-catalog.json`. Run this after installing or updating icon pack dependencies.
 
+## Agent Skill (skills.sh)
+
+This repository includes a reusable agent skill at `.agents/skills/icon-bundle-generator/`.
+
+What it provides:
+
+- API-driven icon generation workflow based on `docs/api-reference.md`
+- Automatic favicon asset generation using a bundled Python script
+
+Install locally from this repository:
+
+```bash
+npx skills add . --list
+npx skills add . --skill icon-bundle-generator --agent cursor
+```
+
+Install from GitHub:
+
+```bash
+npx skills add https://github.com/miguelcorderocollar/zdk.icon-generator --skill icon-bundle-generator --agent cursor
+```
+
+Notes:
+
+- `skills.sh` leaderboard entries are driven by `skills` CLI installs.
+- The skill bundles `scripts/generate-bundle-assets.py` for preset-aligned asset generation from SVG.
+
 ## Project Structure
 
 - `app/` — Next.js App Router pages and layout
@@ -93,6 +120,7 @@ The `generate-icons` script processes icons from installed icon packs and genera
   - `adapters/` — Icon pack adapters for normalization (Zendesk Garden, Feather, RemixIcon)
   - `contexts/` — React contexts (RestrictionContext for restricted mode)
 - `docs/` — Product concept, development plan, and platform-specific icon guidelines
+- `.agents/skills/` — Reusable agent skills (including `icon-bundle-generator`)
 - `public/` — Static assets (including generated `icon-catalog.json`)
 - `scripts/` — Build and data processing scripts (icon catalog generation)
 - `e2e/` — Playwright end-to-end tests

--- a/app/api/icons/[id]/route.ts
+++ b/app/api/icons/[id]/route.ts
@@ -34,7 +34,8 @@ export async function GET(
       svg: icon.svg,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Failed to get icon";
+    const message =
+      error instanceof Error ? error.message : "Failed to get icon";
     return NextResponse.json(
       {
         error: "icon_read_failed",

--- a/src/utils/__tests__/generate-bundle-assets-script.test.ts
+++ b/src/utils/__tests__/generate-bundle-assets-script.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const SCRIPT_PATH = resolve(
+  process.cwd(),
+  ".agents/skills/icon-bundle-generator/scripts/generate-bundle-assets.py"
+);
+
+function runScript(args: string[]) {
+  return spawnSync("python3", [SCRIPT_PATH, ...args], {
+    encoding: "utf-8",
+  });
+}
+
+describe("generate-bundle-assets.py", () => {
+  it("shows supported preset IDs in help output", () => {
+    const result = runScript(["--help"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("favicon-bundle");
+    expect(result.stdout).toContain("macos-app-icon");
+    expect(result.stdout).toContain("single-svg");
+  });
+
+  it("requires either --preset or --all-presets", () => {
+    const result = runScript(["--input-svg", "dummy.svg"]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr || result.stdout).toContain(
+      "Provide --preset or --all-presets."
+    );
+  });
+
+  it("validates --ico-sizes format", () => {
+    const result = runScript([
+      "--input-svg",
+      "dummy.svg",
+      "--preset",
+      "single-svg",
+      "--ico-sizes",
+      "abc",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr || result.stdout).toContain("Invalid ICO size");
+  });
+
+  it("generates single-svg bundle without raster dependencies", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "bundle-assets-test-"));
+
+    try {
+      const inputSvg = join(tempDir, "icon.svg");
+      const outputDir = join(tempDir, "out");
+      const svg =
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>';
+
+      writeFileSync(inputSvg, svg, "utf-8");
+
+      const result = runScript([
+        "--input-svg",
+        inputSvg,
+        "--output-dir",
+        outputDir,
+        "--preset",
+        "single-svg",
+      ]);
+
+      expect(result.status).toBe(0);
+
+      const generatedSvg = join(outputDir, "single-svg", "icon.svg");
+      expect(existsSync(generatedSvg)).toBe(true);
+      expect(readFileSync(generatedSvg, "utf-8")).toBe(svg);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/utils/icon-catalog-server.ts
+++ b/src/utils/icon-catalog-server.ts
@@ -144,13 +144,11 @@ export async function getIconPacksServer(): Promise<
 > {
   const catalog = await loadIconCatalogServer();
 
-  return (Object.keys(catalog.byPack) as IconPack[])
-    .sort()
-    .map((pack) => ({
-      id: pack,
-      count: catalog.byPack[pack]?.length ?? 0,
-      license: catalog.licenses[pack],
-    }));
+  return (Object.keys(catalog.byPack) as IconPack[]).sort().map((pack) => ({
+    id: pack,
+    count: catalog.byPack[pack]?.length ?? 0,
+    license: catalog.licenses[pack],
+  }));
 }
 
 export function clearIconCatalogServerCache(): void {

--- a/src/utils/renderer-server.ts
+++ b/src/utils/renderer-server.ts
@@ -63,7 +63,9 @@ function parseSvg(svgString: string): {
 
   const inheritedFill = fillMatch ? fillMatch[1] : undefined;
   const inheritedStroke = strokeMatch ? strokeMatch[1] : undefined;
-  const inheritedStrokeWidth = strokeWidthMatch ? strokeWidthMatch[1] : undefined;
+  const inheritedStrokeWidth = strokeWidthMatch
+    ? strokeWidthMatch[1]
+    : undefined;
   const inheritedStrokeLinecap = strokeLinecapMatch
     ? strokeLinecapMatch[1]
     : undefined;


### PR DESCRIPTION
## Summary
- add a publishable `.agents/skills/icon-bundle-generator` skill that defaults to `https://bundle-icon-generator.vercel.app` and documents API-driven icon bundle workflows
- add `generate-bundle-assets.py` to generate preset-aligned bundles (favicon, PWA, macOS, Raycast, social, Zendesk PNG-only, single exports)
- add Vitest coverage for script CLI behavior and include README install instructions for `skills.sh`

## Test plan
- [x] `bun run verify`
- [x] `bun run format`
- [x] `bun run test:run`

Made with [Cursor](https://cursor.com)