### PR TITLE
Fix Zendesk SVG preview and export rendering

### DIFF
--- a/src/components/PresetPreview.tsx
+++ b/src/components/PresetPreview.tsx
@@ -11,6 +11,7 @@ import { AlertTriangle } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import type { IconGeneratorState } from "../hooks/use-icon-generator";
 import type { ExportPreset, ExportVariantConfig } from "@/src/types/preset";
+import { SVG_SPECS } from "@/src/constants/app";
 import {
   renderPng,
   renderPngFromImage,
@@ -24,6 +25,7 @@ import {
   getColorOverride,
   getColorAnalysis,
 } from "../utils/image-color-analysis";
+import { isZendeskLocationSvgFile } from "../utils/zendesk-svg";
 
 export interface PresetPreviewProps {
   preset: ExportPreset;
@@ -131,13 +133,32 @@ export function PresetPreview({
             let url: string | null = null;
 
             if (variant.format === "svg" && icon) {
-              // SVG rendering
+              // Match export behavior so preset previews are faithful to output files.
+              const artboardSize = SVG_SPECS.PADDED_SIZE;
+              const minSize = 48;
+              const maxSize = 300;
+              const maxPadding = 6;
+              const minPadding = -6;
+              const svgSize = state.svgIconSize ?? state.iconSize;
+              const padding =
+                maxPadding -
+                ((svgSize - minSize) / (maxSize - minSize)) *
+                  (maxPadding - minPadding);
+
+              const requestedSize = Math.max(variant.width, variant.height);
+              const displaySize = Math.min(requestedSize, artboardSize);
+              const isZendeskLocationSvg = isZendeskLocationSvgFile(
+                variant.filename
+              );
+
               const svgString = renderSvg({
                 icon,
                 backgroundColor: state.backgroundColor,
                 iconColor: state.iconColor,
-                size: Math.min(variant.width, variant.height),
-                padding: 4,
+                size: artboardSize,
+                padding,
+                outputSize: displaySize,
+                zendeskLocationMode: isZendeskLocationSvg,
               });
               const blob = new Blob([svgString], { type: "image/svg+xml" });
               url = URL.createObjectURL(blob);
@@ -212,7 +233,11 @@ export function PresetPreview({
             newPreviews.push({
               variant,
               url: null,
-              isSkipped: false,
+              isSkipped: true,
+              skipReason:
+                error instanceof Error
+                  ? error.message
+                  : "Failed to generate preview",
             });
           }
         }

--- a/src/components/__tests__/PresetPreview.test.tsx
+++ b/src/components/__tests__/PresetPreview.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PresetPreview } from "../PresetPreview";
 import type { IconGeneratorState } from "../../hooks/use-icon-generator";
 import type { ExportPreset } from "../../types/preset";
+import { SVG_SPECS } from "../../constants/app";
 
 vi.mock("@/components/ui/scroll-area", () => ({
   ScrollArea: ({ children }: { children: React.ReactNode }) => (
@@ -51,6 +52,21 @@ describe("PresetPreview", () => {
     ],
   };
 
+  const mockZendeskSvgPreset: ExportPreset = {
+    id: "zendesk-location-bundle",
+    name: "Zendesk Location Bundle",
+    description: "Zendesk SVG location files",
+    isBuiltIn: true,
+    variants: [
+      {
+        filename: "icon_top_bar.svg",
+        width: 30,
+        height: 30,
+        format: "svg",
+      },
+    ],
+  };
+
   const mockState: IconGeneratorState = {
     selectedLocations: [],
     selectedIconId: "test-icon",
@@ -66,7 +82,7 @@ describe("PresetPreview", () => {
     vi.clearAllMocks();
 
     const { getIconById } = await import("../../utils/icon-catalog");
-    const { renderPng } = await import("../../utils/renderer");
+    const { renderPng, renderSvg } = await import("../../utils/renderer");
 
     vi.mocked(getIconById).mockResolvedValue({
       id: "test-icon",
@@ -79,6 +95,9 @@ describe("PresetPreview", () => {
 
     vi.mocked(renderPng).mockResolvedValue(
       new Blob(["png-preview"], { type: "image/png" })
+    );
+    vi.mocked(renderSvg).mockReturnValue(
+      '<svg viewBox="0 0 30 30"><path fill="currentColor" d="M0 0"/></svg>'
     );
 
     vi.stubGlobal("URL", {
@@ -110,5 +129,27 @@ describe("PresetPreview", () => {
         iconColor: mockState.iconColor,
       })
     );
+  });
+
+  it("uses zendesk SVG export settings for zendesk location variants", async () => {
+    const { renderSvg } = await import("../../utils/renderer");
+
+    render(
+      <PresetPreview
+        preset={mockZendeskSvgPreset}
+        iconId="test-icon"
+        state={mockState}
+      />
+    );
+
+    await waitFor(() => {
+      expect(renderSvg).toHaveBeenCalledWith(
+        expect.objectContaining({
+          size: SVG_SPECS.PADDED_SIZE,
+          outputSize: 30,
+          zendeskLocationMode: true,
+        })
+      );
+    });
   });
 });

--- a/src/utils/__tests__/renderer-server.test.ts
+++ b/src/utils/__tests__/renderer-server.test.ts
@@ -46,4 +46,37 @@ describe("renderer-server", () => {
     expect(output).toContain("currentColor");
     expect(output).not.toContain('fill="#ff0000"');
   });
+
+  it("normalizes zendesk mode output for garden, feather, and remixicon SVG shapes", () => {
+    const cases = [
+      {
+        svg: '<svg viewBox="0 0 24 24"><path fill="#17494D" d="M1 1h22v22H1z"/></svg>',
+        mustNotContain: "#17494D",
+      },
+      {
+        svg: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 1h22v22H1z"/></svg>',
+        mustNotContain: "",
+      },
+      {
+        svg: '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M1 1h22v22H1z"/></svg>',
+        mustNotContain: "",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const output = renderSvgServer({
+        icon: createIcon(testCase.svg),
+        backgroundColor: "#000000",
+        iconColor: "#ffffff",
+        size: 30,
+        zendeskLocationMode: true,
+      });
+
+      expect(output).toContain("currentColor");
+      expect(output).not.toContain('fill="#000000"');
+      if (testCase.mustNotContain) {
+        expect(output).not.toContain(testCase.mustNotContain);
+      }
+    }
+  });
 });

--- a/src/utils/__tests__/renderer.test.ts
+++ b/src/utils/__tests__/renderer.test.ts
@@ -215,6 +215,88 @@ describe("renderer", () => {
       expect(result).toContain("currentColor");
     });
 
+    it("normalizes hardcoded paint to currentColor in zendeskLocationMode", () => {
+      const icon = createMockIcon(
+        '<svg viewBox="0 0 24 24"><path fill="#123456" stroke="#654321" d="M0 0"/></svg>'
+      );
+      const options: SvgRenderOptions = {
+        icon,
+        backgroundColor: "#ff0000",
+        iconColor: "#ffffff",
+        size: 24,
+        zendeskLocationMode: true,
+      };
+
+      const result = renderSvg(options);
+
+      expect(result).toContain("currentColor");
+      expect(result).not.toContain("#123456");
+      expect(result).not.toContain("#654321");
+    });
+
+    it('uses <symbol id="default"> content in zendeskLocationMode', () => {
+      const icon = createMockIcon(
+        '<svg viewBox="0 0 24 24"><symbol id="default" viewBox="0 0 24 24"><path d="M1 1"/></symbol><symbol id="other" viewBox="0 0 24 24"><path d="M2 2"/></symbol></svg>'
+      );
+      const options: SvgRenderOptions = {
+        icon,
+        backgroundColor: "#000000",
+        iconColor: "#ffffff",
+        size: 24,
+        zendeskLocationMode: true,
+      };
+
+      const result = renderSvg(options);
+
+      expect(result).toContain("M1 1");
+      expect(result).not.toContain("M2 2");
+    });
+
+    it("keeps zendesk-mode output compatible across garden, feather, and remixicon SVG shapes", () => {
+      const cases = [
+        {
+          name: "zendesk-garden style (hardcoded fill)",
+          svg: '<svg viewBox="0 0 24 24"><path fill="#17494D" d="M1 1h22v22H1z"/></svg>',
+          mustNotContain: "#17494D",
+        },
+        {
+          name: "feather style (root stroke currentColor)",
+          svg: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 1h22v22H1z"/></svg>',
+          mustNotContain: "",
+        },
+        {
+          name: "remixicon style (root fill currentColor)",
+          svg: '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M1 1h22v22H1z"/></svg>',
+          mustNotContain: "",
+        },
+      ];
+
+      for (const testCase of cases) {
+        const icon = createMockIcon(testCase.svg);
+        const result = renderSvg({
+          icon,
+          backgroundColor: "#000000",
+          iconColor: "#ffffff",
+          size: 30,
+          zendeskLocationMode: true,
+        });
+
+        expect(result, `${testCase.name} should keep currentColor`).toContain(
+          "currentColor"
+        );
+        expect(
+          result,
+          `${testCase.name} should stay transparent (no background rect)`
+        ).not.toContain('fill="#000000"');
+        if (testCase.mustNotContain) {
+          expect(
+            result,
+            `${testCase.name} should not keep hardcoded paint`
+          ).not.toContain(testCase.mustNotContain);
+        }
+      }
+    });
+
     it("preserves stroke attributes from Feather-style icons", () => {
       const icon = createMockIcon(
         '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M0 0"/></svg>'

--- a/src/utils/renderer-server.ts
+++ b/src/utils/renderer-server.ts
@@ -9,6 +9,7 @@ import type { IconMetadata } from "@/src/types/icon";
 import type { BackgroundValue } from "@/src/utils/gradients";
 import { gradientToSvgDef, isGradient } from "@/src/utils/gradients";
 import { applySvgColor } from "@/src/utils/renderer";
+import { toZendeskStaticSvgSource } from "@/src/utils/zendesk-svg";
 
 export interface ServerSvgRenderOptions {
   icon: IconMetadata;
@@ -99,6 +100,10 @@ export function renderSvgServer(options: ServerSvgRenderOptions): string {
     zendeskLocationMode = false,
   } = options;
 
+  const svgSource = zendeskLocationMode
+    ? toZendeskStaticSvgSource(icon.svg)
+    : icon.svg;
+
   const {
     viewBox,
     content,
@@ -108,7 +113,7 @@ export function renderSvgServer(options: ServerSvgRenderOptions): string {
     inheritedStrokeLinecap,
     inheritedStrokeLinejoin,
     isRasterized,
-  } = parseSvg(icon.svg);
+  } = parseSvg(svgSource);
 
   const shouldSkipColorTransform =
     zendeskLocationMode ||

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -12,6 +12,10 @@ import {
   createCanvasGradient,
 } from "./gradients";
 import { compressToMaxSize } from "./image-compression";
+import {
+  isZendeskLocationSvgFile,
+  toZendeskStaticSvgSource,
+} from "./zendesk-svg";
 
 /**
  * Parse hex color to RGB components
@@ -375,6 +379,10 @@ export function renderSvg(options: SvgRenderOptions): string {
     zendeskLocationMode = false,
   } = options;
 
+  const svgSource = zendeskLocationMode
+    ? toZendeskStaticSvgSource(icon.svg)
+    : icon.svg;
+
   const {
     viewBox,
     content,
@@ -384,7 +392,7 @@ export function renderSvg(options: SvgRenderOptions): string {
     inheritedStrokeLinecap,
     inheritedStrokeLinejoin,
     isRasterized,
-  } = parseSvg(icon.svg);
+  } = parseSvg(svgSource);
 
   // Skip color transformation for:
   // - Rasterized icons (emojis)
@@ -1080,16 +1088,6 @@ export async function renderPngFromImage(
 }
 
 /**
- * Zendesk location SVG filenames that require transparent backgrounds
- * and no hardcoded fill colors (uses currentColor for Zendesk CSS styling)
- */
-const ZENDESK_LOCATION_SVG_FILES = [
-  "icon_top_bar.svg",
-  "icon_ticket_editor.svg",
-  "icon_nav_bar.svg",
-];
-
-/**
  * Supported export format type
  */
 export type ExportFormatType = "png" | "jpeg" | "webp" | "svg" | "ico";
@@ -1128,9 +1126,7 @@ export async function generateExportAssets(
 
       // Check if this is a Zendesk location SVG (top_bar, ticket_editor, nav_bar)
       // These require transparent backgrounds and no hardcoded fill colors
-      const isZendeskLocationSvg = ZENDESK_LOCATION_SVG_FILES.includes(
-        variant.filename
-      );
+      const isZendeskLocationSvg = isZendeskLocationSvgFile(variant.filename);
 
       // Use svgIconSize for SVG exports to control icon density within the artboard
       // Map svgIconSize (48-300px) to padding (6px to -6px range)

--- a/src/utils/zendesk-svg.ts
+++ b/src/utils/zendesk-svg.ts
@@ -1,0 +1,233 @@
+/**
+ * Utilities for Zendesk location SVG handling.
+ *
+ * These helpers are used only for Zendesk location icon exports
+ * (icon_top_bar.svg, icon_nav_bar.svg, icon_ticket_editor.svg).
+ */
+
+export const ZENDESK_LOCATION_SVG_FILES = [
+  "icon_top_bar.svg",
+  "icon_ticket_editor.svg",
+  "icon_nav_bar.svg",
+];
+
+export function isZendeskLocationSvgFile(filename: string): boolean {
+  return ZENDESK_LOCATION_SVG_FILES.includes(filename);
+}
+
+export interface ZendeskSvgAnalysis {
+  hasSymbolElements: boolean;
+  hasDefaultSymbol: boolean;
+  hasRasterImage: boolean;
+  hasHardcodedPaint: boolean;
+  hasUnsupportedPaintServers: boolean;
+}
+
+interface ParsedSvgRoot {
+  openTag: string;
+  innerContent: string;
+}
+
+interface ParsedSymbol {
+  attrs: string;
+  innerContent: string;
+}
+
+function parseSvgRoot(svg: string): ParsedSvgRoot | null {
+  const openTagMatch = svg.match(/<svg\b[^>]*>/i);
+  const rootMatch = svg.match(/<svg\b[^>]*>([\s\S]*?)<\/svg>/i);
+  if (!openTagMatch || !rootMatch) {
+    return null;
+  }
+
+  return {
+    openTag: openTagMatch[0],
+    innerContent: rootMatch[1],
+  };
+}
+
+function parseDefaultSymbol(svg: string): ParsedSymbol | null {
+  const symbolRegex = /<symbol\b([^>]*)>([\s\S]*?)<\/symbol>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = symbolRegex.exec(svg)) !== null) {
+    const attrs = match[1] ?? "";
+    const idMatch = attrs.match(/\bid=["']([^"']+)["']/i);
+    const id = idMatch?.[1]?.trim().toLowerCase();
+    if (id === "default") {
+      return {
+        attrs,
+        innerContent: match[2] ?? "",
+      };
+    }
+  }
+
+  return null;
+}
+
+function hasAttr(tag: string, attrName: string): boolean {
+  const regex = new RegExp(`\\b${attrName}=["'][^"']*["']`, "i");
+  return regex.test(tag);
+}
+
+function getAttr(tag: string, attrName: string): string | null {
+  const regex = new RegExp(`\\b${attrName}=["']([^"']*)["']`, "i");
+  const match = tag.match(regex);
+  return match?.[1] ?? null;
+}
+
+function withAttr(tag: string, attrName: string, attrValue: string): string {
+  const attrRegex = new RegExp(`\\b${attrName}=["'][^"']*["']`, "i");
+  if (attrRegex.test(tag)) {
+    return tag.replace(attrRegex, `${attrName}="${attrValue}"`);
+  }
+  return tag.replace(/>$/, ` ${attrName}="${attrValue}">`);
+}
+
+function isPreservedPaintValue(rawValue: string): boolean {
+  const value = rawValue.trim().toLowerCase();
+  if (!value) return false;
+  if (value === "none" || value === "transparent") return true;
+  if (value.startsWith("url(")) return true;
+  return false;
+}
+
+function isCurrentColorValue(rawValue: string): boolean {
+  const value = rawValue.trim().toLowerCase();
+  return value === "currentcolor" || value === "current-color";
+}
+
+function normalizePaintAttributesToCurrentColor(input: string): string {
+  let result = input;
+
+  result = result.replace(/fill=["']([^"']*)["']/gi, (match, fillValue) => {
+    if (
+      isPreservedPaintValue(fillValue) ||
+      isCurrentColorValue(fillValue) ||
+      fillValue.trim() === ""
+    ) {
+      return match;
+    }
+    return 'fill="currentColor"';
+  });
+
+  result = result.replace(/stroke=["']([^"']*)["']/gi, (match, strokeValue) => {
+    if (
+      isPreservedPaintValue(strokeValue) ||
+      isCurrentColorValue(strokeValue) ||
+      strokeValue.trim() === ""
+    ) {
+      return match;
+    }
+    return 'stroke="currentColor"';
+  });
+
+  result = result.replace(
+    /fill:\s*([^;]+)(;?)/gi,
+    (match, fillValue: string, suffix: string) => {
+      if (
+        isPreservedPaintValue(fillValue) ||
+        isCurrentColorValue(fillValue) ||
+        fillValue.trim() === ""
+      ) {
+        return match;
+      }
+      return `fill: currentColor${suffix}`;
+    }
+  );
+
+  result = result.replace(
+    /stroke:\s*([^;]+)(;?)/gi,
+    (match, strokeValue: string, suffix: string) => {
+      if (
+        isPreservedPaintValue(strokeValue) ||
+        isCurrentColorValue(strokeValue) ||
+        strokeValue.trim() === ""
+      ) {
+        return match;
+      }
+      return `stroke: currentColor${suffix}`;
+    }
+  );
+
+  return result;
+}
+
+function detectHardcodedPaint(input: string): boolean {
+  const attrRegex = /(fill|stroke)=["']([^"']*)["']/gi;
+  let attrMatch: RegExpExecArray | null;
+  while ((attrMatch = attrRegex.exec(input)) !== null) {
+    const value = attrMatch[2] ?? "";
+    if (
+      value.trim() !== "" &&
+      !isPreservedPaintValue(value) &&
+      !isCurrentColorValue(value)
+    ) {
+      return true;
+    }
+  }
+
+  const styleRegex = /(fill|stroke)\s*:\s*([^;]+)(;?)/gi;
+  let styleMatch: RegExpExecArray | null;
+  while ((styleMatch = styleRegex.exec(input)) !== null) {
+    const value = styleMatch[2] ?? "";
+    if (
+      value.trim() !== "" &&
+      !isPreservedPaintValue(value) &&
+      !isCurrentColorValue(value)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function analyzeZendeskSvg(svg: string): ZendeskSvgAnalysis {
+  const hasSymbolElements = /<symbol\b/i.test(svg);
+  const hasDefaultSymbol = /<symbol\b[^>]*\bid=["']default["'][^>]*>/i.test(
+    svg
+  );
+  const hasRasterImage = /<image\b/i.test(svg);
+  const hasUnsupportedPaintServers =
+    /<(linearGradient|radialGradient|pattern|filter)\b/i.test(svg);
+  const hasHardcodedPaint = detectHardcodedPaint(svg);
+
+  return {
+    hasSymbolElements,
+    hasDefaultSymbol,
+    hasRasterImage,
+    hasHardcodedPaint,
+    hasUnsupportedPaintServers,
+  };
+}
+
+export function toZendeskStaticSvgSource(svg: string): string {
+  const root = parseSvgRoot(svg);
+  if (!root) {
+    throw new Error("Invalid SVG format");
+  }
+
+  let openTag = root.openTag;
+  let content = root.innerContent;
+
+  const defaultSymbol = parseDefaultSymbol(svg);
+  if (defaultSymbol) {
+    // Promote <symbol id="default"> to a plain <svg> source for static export.
+    openTag = `<svg${defaultSymbol.attrs ? ` ${defaultSymbol.attrs.trim()}` : ""}>`;
+    content = defaultSymbol.innerContent;
+
+    // Carry the root viewBox when the symbol doesn't provide one.
+    if (!hasAttr(openTag, "viewBox")) {
+      const rootViewBox = getAttr(root.openTag, "viewBox");
+      if (rootViewBox) {
+        openTag = withAttr(openTag, "viewBox", rootViewBox);
+      }
+    }
+  }
+
+  const normalizedOpenTag = normalizePaintAttributesToCurrentColor(openTag);
+  const normalizedContent = normalizePaintAttributesToCurrentColor(content);
+
+  return `${normalizedOpenTag}${normalizedContent}</svg>`;
+}


### PR DESCRIPTION
## Summary
- Align preset previews with Zendesk SVG export behavior so location bundles render the same in the UI and in generated assets.
- Add Zendesk SVG normalization helpers to promote `symbol#default` content, preserve root `viewBox` when needed, and convert hardcoded paint to `currentColor`.
- Update server/client SVG render paths and add tests covering Zendesk location files plus mixed icon SVG shapes.

## Testing
- `bun run build`
- `bun run lint`
- `bun run test:run`
- `bun run test:e2e`