### PR TITLE
UI rework: border/corner controls, compact color picker, and preset/export updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ App Icon Generator is a local-first tool for crafting icon bundles for any platf
   - **Custom Presets**: Create and save your own export presets
 - **Customization Controls**:
   - Customize background and icon colors with color picker
+  - Configure rounded corners and border (color/width) for opaque exports
   - Advanced background modes:
     - Solid color backgrounds
     - Linear gradients with customizable stops and angles

--- a/app/api/__tests__/routes.test.ts
+++ b/app/api/__tests__/routes.test.ts
@@ -90,9 +90,17 @@ describe("API routes", () => {
     expect(body.svg).toBe("<svg>rendered</svg>");
     expect(body.icon.id).toBe("feather-star");
     expect(body.settings.padding).toBe(8);
+    expect(body.settings.cornerRadius).toBe(0);
+    expect(body.settings.borderEnabled).toBe(false);
+    expect(body.settings.borderColor).toBe("#ffffff");
+    expect(body.settings.borderWidth).toBe(6);
     expect(renderSvgServer).toHaveBeenCalledWith(
       expect.objectContaining({
         padding: 8,
+        cornerRadius: 0,
+        borderEnabled: false,
+        borderColor: "#ffffff",
+        borderWidth: 6,
       })
     );
   });

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -42,6 +42,10 @@ const generateRequestSchema = z.object({
   padding: z.number().min(-200).max(200).default(8),
   outputSize: z.number().int().min(16).max(4096).optional(),
   zendeskLocationMode: z.boolean().default(false),
+  cornerRadius: z.number().min(0).max(100).default(0),
+  borderEnabled: z.boolean().default(false),
+  borderColor: hexColorSchema.default("#ffffff"),
+  borderWidth: z.number().min(0).max(64).default(6),
   filename: z.string().min(1).max(120).optional(),
 });
 
@@ -99,6 +103,10 @@ export async function POST(request: NextRequest) {
       padding: payload.padding,
       outputSize: payload.outputSize,
       zendeskLocationMode: payload.zendeskLocationMode,
+      cornerRadius: payload.cornerRadius,
+      borderEnabled: payload.borderEnabled,
+      borderColor: payload.borderColor,
+      borderWidth: payload.borderWidth,
     });
 
     if (shouldReturnRawSvg(request)) {
@@ -125,6 +133,10 @@ export async function POST(request: NextRequest) {
         padding: payload.padding,
         outputSize: payload.outputSize ?? payload.size,
         zendeskLocationMode: payload.zendeskLocationMode,
+        cornerRadius: payload.cornerRadius,
+        borderEnabled: payload.borderEnabled,
+        borderColor: payload.borderColor,
+        borderWidth: payload.borderWidth,
       },
       svg,
     });

--- a/app/globals.css
+++ b/app/globals.css
@@ -162,6 +162,40 @@
   }
 }
 
+@keyframes accordion-down {
+  from {
+    height: 0;
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    height: var(--radix-accordion-content-height);
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes accordion-up {
+  from {
+    height: var(--radix-accordion-content-height);
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    height: 0;
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+
+[data-slot="accordion-content"][data-state="open"] {
+  animation: accordion-down 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+[data-slot="accordion-content"][data-state="closed"] {
+  animation: accordion-up 180ms cubic-bezier(0.7, 0, 0.84, 0);
+}
+
 /* Emoji Picker Wrapper - Light Mode */
 .emoji-picker-wrapper {
   background-color: hsl(var(--card));

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,12 @@ import { CustomizationControlsPane } from "@/components/CustomizationControlsPan
 import { PreviewPane } from "@/components/PreviewPane";
 import { useIconGenerator } from "@/src/hooks/use-icon-generator";
 import { useCanvasEditor } from "@/src/hooks/use-canvas-editor";
-import { APP_NAME, APP_DESCRIPTION, ICON_PACKS } from "@/src/constants/app";
+import {
+  APP_NAME,
+  APP_DESCRIPTION,
+  DEFAULT_APPEARANCE,
+  ICON_PACKS,
+} from "@/src/constants/app";
 import {
   Dialog,
   DialogContent,
@@ -156,6 +161,10 @@ export default function Home() {
       const firstStyle = allowedStyles[0];
       actions.setBackgroundColor(firstStyle.backgroundColor);
       actions.setIconColor(firstStyle.iconColor);
+      actions.setCornerRadius(DEFAULT_APPEARANCE.CORNER_RADIUS);
+      actions.setBorderEnabled(DEFAULT_APPEARANCE.BORDER_ENABLED);
+      actions.setBorderColor(DEFAULT_APPEARANCE.BORDER_COLOR);
+      actions.setBorderWidth(DEFAULT_APPEARANCE.BORDER_WIDTH);
       hasSetRestrictedStyleRef.current = true;
     }
   }, [isRestrictionLoading, isRestricted, allowedStyles, actions]);
@@ -340,7 +349,7 @@ export default function Home() {
             <>
               {/* Canvas mode: 1/3 controls + 2/3 canvas editor */}
               {/* Left: Source selector + Background controls */}
-              <div className="flex flex-shrink-0 flex-col overflow-hidden md:h-full md:w-80">
+              <div className="flex flex-shrink-0 flex-col overflow-hidden md:h-full md:w-[28rem]">
                 <CanvasControlsPane
                   selectedPack={state.selectedPack}
                   onPackChange={actions.setSelectedPack}
@@ -383,6 +392,14 @@ export default function Home() {
                   onBackgroundColorChange={actions.setBackgroundColor}
                   iconColor={state.iconColor}
                   onIconColorChange={actions.setIconColor}
+                  cornerRadius={state.cornerRadius}
+                  onCornerRadiusChange={actions.setCornerRadius}
+                  borderEnabled={state.borderEnabled}
+                  onBorderEnabledChange={actions.setBorderEnabled}
+                  borderColor={state.borderColor}
+                  onBorderColorChange={actions.setBorderColor}
+                  borderWidth={state.borderWidth}
+                  onBorderWidthChange={actions.setBorderWidth}
                   iconSize={state.iconSize}
                   onIconSizeChange={actions.setIconSize}
                   svgIconSize={state.svgIconSize}

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "zdk-icon-generator",
       "dependencies": {
+        "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -327,11 +328,15 @@
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
+    "@radix-ui/react-accordion": ["@radix-ui/react-accordion@1.2.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA=="],
+
     "@radix-ui/react-alert-dialog": ["@radix-ui/react-alert-dialog@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw=="],
 
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 
     "@radix-ui/react-checkbox": ["@radix-ui/react-checkbox@1.3.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw=="],
+
+    "@radix-ui/react-collapsible": ["@radix-ui/react-collapsible@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA=="],
 
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
 

--- a/components/CustomizationControlsPane.tsx
+++ b/components/CustomizationControlsPane.tsx
@@ -93,6 +93,7 @@ export function CustomizationControlsPane({
   // Presets hook
   const {
     exportPresets,
+    selectedExportPresetId,
     createExportPreset,
     updateExportPreset,
     deleteExportPreset,
@@ -121,13 +122,20 @@ export function CustomizationControlsPane({
   // Check if current icon is a custom image
   const isCustomImage = isCustomImageIcon(selectedIconId);
 
-  // Check if the restricted export options include SVG variants
+  // Check whether the currently active export preset includes SVG variants
   const hasSvgVariants = React.useMemo(() => {
-    if (!allowedExportPresets) return true;
-    return allowedExportPresets.some((preset) =>
-      preset.variants.some((variant) => variant.format === "svg")
-    );
-  }, [allowedExportPresets]);
+    const effectiveExportPresets = allowedExportPresets ?? exportPresets;
+    const activePreset =
+      effectiveExportPresets.find(
+        (preset) => preset.id === selectedExportPresetId
+      ) ?? effectiveExportPresets[0];
+
+    if (!activePreset) {
+      return false;
+    }
+
+    return activePreset.variants.some((variant) => variant.format === "svg");
+  }, [allowedExportPresets, exportPresets, selectedExportPresetId]);
 
   // Get the selected style preset (for accessing color palette)
   const selectedStylePreset = React.useMemo(() => {

--- a/components/CustomizationControlsPane.tsx
+++ b/components/CustomizationControlsPane.tsx
@@ -2,23 +2,35 @@
 
 import * as React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { Settings, AlertTriangle } from "lucide-react";
+import {
+  Settings,
+  Palette,
+  SlidersHorizontal,
+  SquareRoundCorner,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Switch } from "@/components/ui/switch";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { ColorPicker } from "@/src/components/ColorPicker";
 import { EffectSlider } from "@/src/components/EffectSlider";
 import { BackgroundControls } from "@/src/components/BackgroundControls";
-import { ExportPresetSelector } from "@/src/components/ExportPresetSelector";
-import { ExportPresetEditor } from "@/src/components/ExportPresetEditor";
-import { StylePresetSelector } from "@/src/components/StylePresetSelector";
 import { StylePresetEditor } from "@/src/components/StylePresetEditor";
 import { PresetSettingsModal } from "@/src/components/PresetSettingsModal";
-import { DEFAULT_COLORS, ICON_GRID } from "@/src/constants/app";
+import { StylePresetSelector } from "@/src/components/StylePresetSelector";
+import {
+  DEFAULT_APPEARANCE,
+  DEFAULT_COLORS,
+  ICON_GRID,
+} from "@/src/constants/app";
 import { useDebouncedValue } from "@/src/hooks/use-debounced-value";
 import { usePresets } from "@/src/hooks/use-presets";
 import type { BackgroundValue } from "@/src/utils/gradients";
-import type { ExportPreset, StylePreset } from "@/src/types/preset";
+import type { StylePreset } from "@/src/types/preset";
 import { isCustomImageIcon } from "@/src/utils/locations";
 import { useRestriction } from "@/src/contexts/RestrictionContext";
 import { RestrictedStyleSelector } from "@/src/components/RestrictedStyleSelector";
@@ -30,6 +42,14 @@ export interface CustomizationControlsPaneProps {
   onBackgroundColorChange?: (color: BackgroundValue) => void;
   iconColor?: string;
   onIconColorChange?: (color: string) => void;
+  cornerRadius?: number;
+  onCornerRadiusChange?: (radius: number) => void;
+  borderEnabled?: boolean;
+  onBorderEnabledChange?: (enabled: boolean) => void;
+  borderColor?: string;
+  onBorderColorChange?: (color: string) => void;
+  borderWidth?: number;
+  onBorderWidthChange?: (width: number) => void;
   iconSize?: number;
   onIconSizeChange?: (size: number) => void;
   svgIconSize?: number;
@@ -46,6 +66,14 @@ export function CustomizationControlsPane({
   onBackgroundColorChange,
   iconColor = DEFAULT_COLORS.ICON,
   onIconColorChange,
+  cornerRadius = DEFAULT_APPEARANCE.CORNER_RADIUS,
+  onCornerRadiusChange,
+  borderEnabled = DEFAULT_APPEARANCE.BORDER_ENABLED,
+  onBorderEnabledChange,
+  borderColor = DEFAULT_APPEARANCE.BORDER_COLOR,
+  onBorderColorChange,
+  borderWidth = DEFAULT_APPEARANCE.BORDER_WIDTH,
+  onBorderWidthChange,
   iconSize = ICON_GRID.DEFAULT_ICON_SIZE,
   onIconSizeChange,
   svgIconSize = ICON_GRID.DEFAULT_ICON_SIZE,
@@ -65,8 +93,6 @@ export function CustomizationControlsPane({
   // Presets hook
   const {
     exportPresets,
-    selectedExportPresetId,
-    selectExportPreset,
     createExportPreset,
     updateExportPreset,
     deleteExportPreset,
@@ -83,53 +109,25 @@ export function CustomizationControlsPane({
     hasCustomStylePresets,
   } = usePresets();
 
-  // Export preset editor state
-  const [showExportEditor, setShowExportEditor] = React.useState(false);
-  const [editingExportPreset, setEditingExportPreset] = React.useState<
-    ExportPreset | undefined
-  >();
-
   // Style preset editor state
   const [showStyleEditor, setShowStyleEditor] = React.useState(false);
   const [editingStylePreset, setEditingStylePreset] = React.useState<
     StylePreset | undefined
   >();
+  const [openSection, setOpenSection] = React.useState<string | undefined>(
+    "colors"
+  );
 
   // Check if current icon is a custom image
   const isCustomImage = isCustomImageIcon(selectedIconId);
 
-  // Determine the effective presets list (restricted or all)
-  const effectiveExportPresets = allowedExportPresets ?? exportPresets;
-
-  // Determine the actual selected preset from the effective list
-  const actualSelectedExportPreset = React.useMemo(() => {
-    return effectiveExportPresets.find((p) => p.id === selectedExportPresetId);
-  }, [effectiveExportPresets, selectedExportPresetId]);
-
-  // Auto-select first allowed export preset if current is not allowed
-  React.useEffect(() => {
-    if (!isRestricted || !allowedExportPresets) return;
-
-    // Check if current preset is in the allowed list
-    const isCurrentAllowed = allowedExportPresets.some(
-      (p) => p.id === selectedExportPresetId
-    );
-
-    if (!isCurrentAllowed && allowedExportPresets.length > 0) {
-      selectExportPreset(allowedExportPresets[0].id);
-    }
-  }, [
-    isRestricted,
-    allowedExportPresets,
-    selectedExportPresetId,
-    selectExportPreset,
-  ]);
-
-  // Check if selected export preset has SVG variants
+  // Check if the restricted export options include SVG variants
   const hasSvgVariants = React.useMemo(() => {
-    if (!actualSelectedExportPreset) return false;
-    return actualSelectedExportPreset.variants.some((v) => v.format === "svg");
-  }, [actualSelectedExportPreset]);
+    if (!allowedExportPresets) return true;
+    return allowedExportPresets.some((preset) =>
+      preset.variants.some((variant) => variant.format === "svg")
+    );
+  }, [allowedExportPresets]);
 
   // Get the selected style preset (for accessing color palette)
   const selectedStylePreset = React.useMemo(() => {
@@ -146,8 +144,27 @@ export function CustomizationControlsPane({
       if (onIconColorChange) {
         onIconColorChange(preset.iconColor);
       }
+      if (onCornerRadiusChange) {
+        onCornerRadiusChange(preset.cornerRadius);
+      }
+      if (onBorderEnabledChange) {
+        onBorderEnabledChange(preset.borderEnabled);
+      }
+      if (onBorderColorChange) {
+        onBorderColorChange(preset.borderColor);
+      }
+      if (onBorderWidthChange) {
+        onBorderWidthChange(preset.borderWidth);
+      }
     },
-    [onBackgroundColorChange, onIconColorChange]
+    [
+      onBackgroundColorChange,
+      onIconColorChange,
+      onCornerRadiusChange,
+      onBorderEnabledChange,
+      onBorderColorChange,
+      onBorderWidthChange,
+    ]
   );
 
   // Handle applying a restricted style
@@ -162,28 +179,6 @@ export function CustomizationControlsPane({
     },
     [onBackgroundColorChange, onIconColorChange]
   );
-
-  // Export preset handlers
-  const handleCreateExportPreset = () => {
-    setEditingExportPreset(undefined);
-    setShowExportEditor(true);
-  };
-
-  const handleEditExportPreset = (preset: ExportPreset) => {
-    setEditingExportPreset(preset);
-    setShowExportEditor(true);
-  };
-
-  const handleSaveExportPreset = (
-    preset: Omit<ExportPreset, "id" | "isBuiltIn" | "createdAt">
-  ) => {
-    if (editingExportPreset) {
-      updateExportPreset(editingExportPreset.id, preset);
-    } else {
-      const newPreset = createExportPreset(preset);
-      selectExportPreset(newPreset.id);
-    }
-  };
 
   // Style preset handlers
   const handleCreateStylePreset = () => {
@@ -201,6 +196,12 @@ export function CustomizationControlsPane({
   ) => {
     if (editingStylePreset) {
       updateStylePreset(editingStylePreset.id, preset);
+      if (selectedStylePresetId === editingStylePreset.id) {
+        handleApplyStylePreset({
+          ...editingStylePreset,
+          ...preset,
+        });
+      }
     } else {
       const newPreset = createStylePreset(preset);
       selectStylePreset(newPreset.id);
@@ -285,50 +286,11 @@ export function CustomizationControlsPane({
           />
         ) : null}
       </CardHeader>
-      <CardContent className="flex flex-1 flex-col gap-6 overflow-y-auto">
-        {/* Export Preset Selection */}
-        <ExportPresetSelector
-          presets={effectiveExportPresets}
-          selectedPresetId={selectedExportPresetId}
-          onSelectPreset={selectExportPreset}
-          onCreatePreset={
-            !isRestrictionLoading && !isRestricted
-              ? handleCreateExportPreset
-              : undefined
-          }
-          onEditPreset={
-            !isRestrictionLoading && !isRestricted
-              ? handleEditExportPreset
-              : undefined
-          }
-          onDeletePreset={
-            !isRestrictionLoading && !isRestricted
-              ? deleteExportPreset
-              : undefined
-          }
-        />
-
-        {/* SVG Warning for Custom Images */}
-        {isCustomImage && hasSvgVariants && (
-          <Alert
-            variant="default"
-            className="border-amber-500/50 bg-amber-500/10"
-          >
-            <AlertTriangle className="h-4 w-4 text-amber-500" />
-            <AlertDescription className="text-xs">
-              Custom images cannot be exported as SVG. SVG files in this preset
-              will be skipped during export.
-            </AlertDescription>
-          </Alert>
-        )}
-
-        <Separator />
-
-        {/* Style Preset Selection - hidden in restricted mode */}
+      <CardContent className="flex flex-1 flex-col gap-3 overflow-y-auto">
         {!isRestrictionLoading &&
         !isRestricted &&
         (onBackgroundColorChange || onIconColorChange) ? (
-          <>
+          <div className="pb-1">
             <StylePresetSelector
               presets={stylePresets}
               selectedPresetId={selectedStylePresetId}
@@ -338,106 +300,196 @@ export function CustomizationControlsPane({
               onEditPreset={handleEditStylePreset}
               onDeletePreset={deleteStylePreset}
             />
-
-            <Separator />
-          </>
+          </div>
         ) : null}
 
-        {/* Icon Size */}
-        {onIconSizeChange && (
-          <div className="space-y-4">
-            <h3 className="text-sm font-medium">Icon Size</h3>
-            <EffectSlider
-              id="icon-size"
-              label={hasSvgVariants && !isCustomImage ? "PNG Size" : "Size"}
-              value={localIconSize}
-              onChange={handleIconSizeChange}
-              min={ICON_GRID.MIN_ICON_SIZE}
-              max={200}
-              step={4}
-              unit="px"
-            />
-            <p className="text-xs text-muted-foreground">
-              Controls the size of the icon within the export canvas.
-            </p>
-
-            {/* SVG Icon Size - only shown when preset has SVG variants and not custom image */}
-            {hasSvgVariants && !isCustomImage && onSvgIconSizeChange && (
-              <>
-                <EffectSlider
-                  id="svg-icon-size"
-                  label="SVG Size"
-                  value={localSvgIconSize}
-                  onChange={handleSvgIconSizeChange}
-                  min={ICON_GRID.MIN_ICON_SIZE}
-                  max={300}
-                  step={4}
-                  unit="px"
+        <Accordion
+          type="single"
+          collapsible
+          value={openSection}
+          onValueChange={setOpenSection}
+          className="space-y-3"
+        >
+          {onIconSizeChange ? (
+            <AccordionItem value="size">
+              <AccordionTrigger>
+                <AccordionSectionHeader
+                  icon={SlidersHorizontal}
+                  title="Icon Size"
                 />
-                <p className="text-xs text-muted-foreground">
-                  Controls the size of the icon within SVG files.
-                </p>
-              </>
-            )}
-          </div>
-        )}
-
-        <Separator />
-
-        {/* Color Controls */}
-        <div className="space-y-4">
-          <h3 className="text-sm font-medium">Colors</h3>
-          {!isRestrictionLoading && isRestricted ? (
-            /* Restricted mode - show simplified style selector */
-            <RestrictedStyleSelector
-              styles={allowedStyles}
-              currentBackground={backgroundColor}
-              currentIconColor={iconColor}
-              onStyleSelect={handleApplyRestrictedStyle}
-            />
-          ) : (
-            /* Normal mode - show full color controls */
-            <>
-              {onIconColorChange &&
-                !selectedIconId?.startsWith("emoji-") &&
-                !isCustomImage && (
-                  <ColorPicker
-                    id="icon-color"
-                    label="Icon Color"
-                    value={iconColor}
-                    onChange={onIconColorChange}
-                    colorType="icon"
-                    isCustomSvg={selectedIconId?.startsWith("custom-svg-")}
-                    paletteColors={selectedStylePreset?.colorPalette}
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="space-y-4">
+                  <EffectSlider
+                    id="icon-size"
+                    label={
+                      hasSvgVariants && !isCustomImage ? "PNG Size" : "Size"
+                    }
+                    value={localIconSize}
+                    onChange={handleIconSizeChange}
+                    min={ICON_GRID.MIN_ICON_SIZE}
+                    max={200}
+                    step={4}
+                    unit="px"
                   />
-                )}
-              {/* Custom image color override for PNG images with uniform color */}
-              {isCustomImage && selectedIconId && (
-                <CustomImageColorOverride
-                  imageId={selectedIconId}
-                  onOverrideChange={onCustomImageColorOverride}
-                  analysisKey={colorAnalysisKey}
-                />
-              )}
-              {onBackgroundColorChange && (
-                <BackgroundControls
-                  value={backgroundColor}
-                  onChange={onBackgroundColorChange}
-                />
-              )}
-            </>
-          )}
-        </div>
-      </CardContent>
+                  <p className="text-xs text-muted-foreground">
+                    Controls the size of the icon within the export canvas.
+                  </p>
 
-      {/* Export Preset Editor Modal */}
-      <ExportPresetEditor
-        open={showExportEditor}
-        onOpenChange={setShowExportEditor}
-        preset={editingExportPreset}
-        onSave={handleSaveExportPreset}
-        mode={editingExportPreset ? "edit" : "create"}
-      />
+                  {hasSvgVariants && !isCustomImage && onSvgIconSizeChange ? (
+                    <>
+                      <EffectSlider
+                        id="svg-icon-size"
+                        label="SVG Size"
+                        value={localSvgIconSize}
+                        onChange={handleSvgIconSizeChange}
+                        min={ICON_GRID.MIN_ICON_SIZE}
+                        max={300}
+                        step={4}
+                        unit="px"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Controls the size of the icon within SVG files.
+                      </p>
+                    </>
+                  ) : null}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          ) : null}
+
+          {!isRestrictionLoading &&
+          !isRestricted &&
+          onCornerRadiusChange &&
+          onBorderEnabledChange &&
+          onBorderWidthChange ? (
+            <AccordionItem value="shape">
+              <AccordionTrigger>
+                <AccordionSectionHeader
+                  icon={SquareRoundCorner}
+                  title="Frame Shape"
+                />
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="space-y-5">
+                  <EffectSlider
+                    id="corner-radius"
+                    label="Corner Radius"
+                    value={cornerRadius}
+                    onChange={onCornerRadiusChange}
+                    min={0}
+                    max={100}
+                    step={1}
+                    unit="%"
+                  />
+
+                  <div className="flex items-center justify-between gap-3 border-t border-border/60 pt-4">
+                    <label
+                      htmlFor="border-enabled"
+                      className="text-sm font-medium"
+                    >
+                      Border
+                    </label>
+                    <Switch
+                      id="border-enabled"
+                      checked={borderEnabled}
+                      onCheckedChange={onBorderEnabledChange}
+                    />
+                  </div>
+
+                  {borderEnabled ? (
+                    <EffectSlider
+                      id="border-width"
+                      label="Border Width"
+                      value={borderWidth}
+                      onChange={onBorderWidthChange}
+                      min={0}
+                      max={40}
+                      step={1}
+                      unit="px"
+                    />
+                  ) : null}
+
+                  {hasSvgVariants ? (
+                    <p className="text-xs text-muted-foreground">
+                      Transparent location SVG exports ignore background shape
+                      and border.
+                    </p>
+                  ) : null}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          ) : null}
+
+          <AccordionItem value="colors">
+            <AccordionTrigger>
+              <AccordionSectionHeader icon={Palette} title="Colors" />
+            </AccordionTrigger>
+            <AccordionContent>
+              {!isRestrictionLoading && isRestricted ? (
+                <RestrictedStyleSelector
+                  styles={allowedStyles}
+                  currentBackground={backgroundColor}
+                  currentIconColor={iconColor}
+                  onStyleSelect={handleApplyRestrictedStyle}
+                />
+              ) : (
+                <div className="space-y-5">
+                  <div className="space-y-4">
+                    <div className="flex items-center gap-2 text-sm font-medium">
+                      <Palette className="h-4 w-4 text-muted-foreground" />
+                      Foreground
+                    </div>
+                    {onIconColorChange &&
+                    !selectedIconId?.startsWith("emoji-") &&
+                    !isCustomImage ? (
+                      <ColorPicker
+                        id="icon-color"
+                        label="Icon Color"
+                        value={iconColor}
+                        onChange={onIconColorChange}
+                        colorType="icon"
+                        isCustomSvg={selectedIconId?.startsWith("custom-svg-")}
+                        paletteColors={selectedStylePreset?.colorPalette}
+                      />
+                    ) : null}
+                    {borderEnabled && onBorderColorChange ? (
+                      <ColorPicker
+                        id="border-color"
+                        label="Border Color"
+                        value={borderColor}
+                        onChange={onBorderColorChange}
+                        colorType="icon"
+                        paletteColors={selectedStylePreset?.colorPalette}
+                      />
+                    ) : null}
+                  </div>
+
+                  {isCustomImage && selectedIconId ? (
+                    <CustomImageColorOverride
+                      imageId={selectedIconId}
+                      onOverrideChange={onCustomImageColorOverride}
+                      analysisKey={colorAnalysisKey}
+                    />
+                  ) : null}
+                  {onBackgroundColorChange ? (
+                    <div className="space-y-4 border-t border-border/60 pt-4">
+                      <div className="flex items-center gap-2 text-sm font-medium">
+                        <Palette className="h-4 w-4 text-muted-foreground" />
+                        Surface
+                      </div>
+                      <BackgroundControls
+                        value={backgroundColor}
+                        onChange={onBackgroundColorChange}
+                      />
+                    </div>
+                  ) : null}
+                </div>
+              )}
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </CardContent>
 
       {/* Style Preset Editor Modal */}
       <StylePresetEditor
@@ -448,5 +500,26 @@ export function CustomizationControlsPane({
         mode={editingStylePreset ? "edit" : "create"}
       />
     </Card>
+  );
+}
+
+interface AccordionSectionHeaderProps {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+}
+
+function AccordionSectionHeader({
+  icon: Icon,
+  title,
+}: AccordionSectionHeaderProps) {
+  return (
+    <div className="flex min-w-0 items-start gap-3">
+      <div className="rounded-lg bg-accent/55 p-2 text-accent-foreground">
+        <Icon className="h-4 w-4" />
+      </div>
+      <div className="min-w-0">
+        <div className="text-sm font-semibold">{title}</div>
+      </div>
+    </div>
   );
 }

--- a/components/PreviewPane.tsx
+++ b/components/PreviewPane.tsx
@@ -24,11 +24,13 @@ import type { CanvasEditorState } from "@/src/types/canvas";
 import type { CanvasEditorActions } from "@/src/hooks/use-canvas-editor";
 import { useCanvasEditor } from "@/src/hooks/use-canvas-editor";
 import { usePresets } from "@/src/hooks/use-presets";
+import { ExportPresetSelector } from "@/src/components/ExportPresetSelector";
+import { ExportPresetEditor } from "@/src/components/ExportPresetEditor";
 import { ExportModal } from "@/src/components/ExportModal";
 import { useIconMetadata } from "@/src/hooks/use-icon-metadata";
 import { isCustomImageIcon } from "@/src/utils/locations";
 import { useRestriction } from "@/src/contexts/RestrictionContext";
-import type { ColorPaletteEntry } from "@/src/types/preset";
+import type { ColorPaletteEntry, ExportPreset } from "@/src/types/preset";
 import {
   getColorOverride,
   getColorAnalysis,
@@ -60,21 +62,48 @@ export function PreviewPane({
   const [editPreviewUrl, setEditPreviewUrl] = React.useState<string | null>(
     null
   );
+  const [showExportEditor, setShowExportEditor] = React.useState(false);
+  const [editingExportPreset, setEditingExportPreset] = React.useState<
+    ExportPreset | undefined
+  >();
   const iconMetadata = useIconMetadata(selectedIconId);
 
   // Presets hook
-  const { exportPresets, selectedExportPresetId, selectedStylePreset } =
-    usePresets();
+  const {
+    exportPresets,
+    selectedExportPresetId,
+    selectedStylePreset,
+    selectExportPreset,
+    createExportPreset,
+    updateExportPreset,
+    deleteExportPreset,
+  } = usePresets();
 
   // Restriction mode
-  const { isRestricted, allowedStyles, allowedExportPresets } =
-    useRestriction();
+  const {
+    isRestricted,
+    allowedStyles,
+    allowedExportPresets,
+    isLoading: isRestrictionLoading,
+  } = useRestriction();
 
   // Determine the effective export presets list and selected preset
   const effectiveExportPresets = allowedExportPresets ?? exportPresets;
   const actualSelectedExportPreset = React.useMemo(() => {
     return effectiveExportPresets.find((p) => p.id === selectedExportPresetId);
   }, [effectiveExportPresets, selectedExportPresetId]);
+  const hasSvgVariants = React.useMemo(() => {
+    if (!actualSelectedExportPreset) return false;
+    return actualSelectedExportPreset.variants.some(
+      (variant) => variant.format === "svg"
+    );
+  }, [actualSelectedExportPreset]);
+
+  React.useEffect(() => {
+    if (effectiveExportPresets.length === 0) return;
+    if (actualSelectedExportPreset) return;
+    selectExportPreset(effectiveExportPresets[0].id);
+  }, [actualSelectedExportPreset, effectiveExportPresets, selectExportPreset]);
 
   // Find the currently active restricted style based on background color
   const activeRestrictedStyle = React.useMemo(() => {
@@ -191,6 +220,10 @@ export function PreviewPane({
             height: 512,
             colorOverride,
             originalColor,
+            cornerRadius: state.cornerRadius,
+            borderEnabled: state.borderEnabled,
+            borderColor: state.borderColor,
+            borderWidth: state.borderWidth,
           });
           if (cancelled) return;
           currentUrl = URL.createObjectURL(blob);
@@ -206,6 +239,10 @@ export function PreviewPane({
             size: state.iconSize,
             width: 512,
             height: 512,
+            cornerRadius: state.cornerRadius,
+            borderEnabled: state.borderEnabled,
+            borderColor: state.borderColor,
+            borderWidth: state.borderWidth,
           });
           if (cancelled) return;
           currentUrl = URL.createObjectURL(blob);
@@ -234,6 +271,33 @@ export function PreviewPane({
       (typeof state?.iconColor === "string" ? state.iconColor : "#ffffff")
     );
   }, [selectedStylePreset?.iconColor, state?.iconColor]);
+
+  const handleCreateExportPreset = React.useCallback(() => {
+    setEditingExportPreset(undefined);
+    setShowExportEditor(true);
+  }, []);
+
+  const handleEditExportPreset = React.useCallback((preset: ExportPreset) => {
+    setEditingExportPreset(preset);
+    setShowExportEditor(true);
+  }, []);
+
+  const handleSaveExportPreset = React.useCallback(
+    (preset: Omit<ExportPreset, "id" | "isBuiltIn" | "createdAt">) => {
+      if (editingExportPreset) {
+        updateExportPreset(editingExportPreset.id, preset);
+      } else {
+        const newPreset = createExportPreset(preset);
+        selectExportPreset(newPreset.id);
+      }
+    },
+    [
+      createExportPreset,
+      editingExportPreset,
+      selectExportPreset,
+      updateExportPreset,
+    ]
+  );
 
   // Calculate export info from selected preset
   const exportInfo = React.useMemo(() => {
@@ -333,22 +397,38 @@ export function PreviewPane({
           </ScrollArea>
 
           {/* Export Button - sticky at bottom */}
-          <div className="flex-shrink-0 border-t pt-3 mt-3 space-y-2">
-            <div className="text-xs text-muted-foreground">
-              {canvasState.layers.length > 0
+          <ExportControls
+            exportPresets={effectiveExportPresets}
+            selectedExportPresetId={selectedExportPresetId}
+            onSelectExportPreset={selectExportPreset}
+            onCreatePreset={
+              !isRestrictionLoading && !isRestricted
+                ? handleCreateExportPreset
+                : undefined
+            }
+            onEditPreset={
+              !isRestrictionLoading && !isRestricted
+                ? handleEditExportPreset
+                : undefined
+            }
+            onDeletePreset={
+              !isRestrictionLoading && !isRestricted
+                ? deleteExportPreset
+                : undefined
+            }
+            infoText={
+              canvasState.layers.length > 0
                 ? `Will export ${exportInfo.exportable} file${exportInfo.exportable !== 1 ? "s" : ""}${exportInfo.skipped > 0 ? ` (${exportInfo.skipped} skipped)` : ""}`
-                : "Add layers to enable export"}
-            </div>
-            <Button
-              className="w-full"
-              size="lg"
-              disabled={!canExport}
-              onClick={() => setIsExportModalOpen(true)}
-            >
-              <Download className="mr-2 size-4" />
-              Export
-            </Button>
-          </div>
+                : "Add layers to enable export"
+            }
+            warningText={
+              hasSvgVariants
+                ? "Canvas mode only exports raster formats. SVG files in this preset will be skipped."
+                : undefined
+            }
+            canExport={canExport}
+            onExport={() => setIsExportModalOpen(true)}
+          />
         </CardContent>
 
         {/* Add Layer Modal */}
@@ -369,6 +449,13 @@ export function PreviewPane({
             canvasState={canvasState}
           />
         )}
+        <ExportPresetEditor
+          open={showExportEditor}
+          onOpenChange={setShowExportEditor}
+          preset={editingExportPreset}
+          onSave={handleSaveExportPreset}
+          mode={editingExportPreset ? "edit" : "create"}
+        />
       </Card>
     );
   }
@@ -445,24 +532,38 @@ export function PreviewPane({
         </Tabs>
 
         {/* Export Button - Sticky at bottom */}
-        <div className="flex-shrink-0 border-t pt-3 mt-3 space-y-2">
-          {canExport && hasSelection && (
-            <div className="text-xs text-muted-foreground">
-              Will export {exportInfo.exportable} file
-              {exportInfo.exportable !== 1 ? "s" : ""}
-              {exportInfo.skipped > 0 && ` (${exportInfo.skipped} skipped)`}
-            </div>
-          )}
-          <Button
-            className="w-full"
-            size="lg"
-            disabled={!canExport || !hasSelection}
-            onClick={() => setIsExportModalOpen(true)}
-          >
-            <Download className="mr-2 size-4" />
-            Export
-          </Button>
-        </div>
+        <ExportControls
+          exportPresets={effectiveExportPresets}
+          selectedExportPresetId={selectedExportPresetId}
+          onSelectExportPreset={selectExportPreset}
+          onCreatePreset={
+            !isRestrictionLoading && !isRestricted
+              ? handleCreateExportPreset
+              : undefined
+          }
+          onEditPreset={
+            !isRestrictionLoading && !isRestricted
+              ? handleEditExportPreset
+              : undefined
+          }
+          onDeletePreset={
+            !isRestrictionLoading && !isRestricted
+              ? deleteExportPreset
+              : undefined
+          }
+          infoText={
+            canExport && hasSelection
+              ? `Will export ${exportInfo.exportable} file${exportInfo.exportable !== 1 ? "s" : ""}${exportInfo.skipped > 0 ? ` (${exportInfo.skipped} skipped)` : ""}`
+              : undefined
+          }
+          warningText={
+            isCustomImage && exportInfo.skipped > 0
+              ? "Custom images cannot be exported as SVG. SVG files in this preset will be skipped during export."
+              : undefined
+          }
+          canExport={canExport && hasSelection}
+          onExport={() => setIsExportModalOpen(true)}
+        />
       </CardContent>
       {state && (
         <ExportModal
@@ -472,6 +573,74 @@ export function PreviewPane({
           selectedLocations={selectedLocations}
         />
       )}
+      <ExportPresetEditor
+        open={showExportEditor}
+        onOpenChange={setShowExportEditor}
+        preset={editingExportPreset}
+        onSave={handleSaveExportPreset}
+        mode={editingExportPreset ? "edit" : "create"}
+      />
     </Card>
+  );
+}
+
+interface ExportControlsProps {
+  exportPresets: ExportPreset[];
+  selectedExportPresetId: string;
+  onSelectExportPreset: (id: string) => void;
+  onCreatePreset?: () => void;
+  onEditPreset?: (preset: ExportPreset) => void;
+  onDeletePreset?: (id: string) => void;
+  infoText?: string;
+  warningText?: string;
+  canExport: boolean;
+  onExport: () => void;
+}
+
+function ExportControls({
+  exportPresets,
+  selectedExportPresetId,
+  onSelectExportPreset,
+  onCreatePreset,
+  onEditPreset,
+  onDeletePreset,
+  infoText,
+  warningText,
+  canExport,
+  onExport,
+}: ExportControlsProps) {
+  return (
+    <div className="mt-3 flex-shrink-0 space-y-3 border-t pt-3">
+      <ExportPresetSelector
+        presets={exportPresets}
+        selectedPresetId={selectedExportPresetId}
+        onSelectPreset={onSelectExportPreset}
+        onCreatePreset={onCreatePreset}
+        onEditPreset={onEditPreset}
+        onDeletePreset={onDeletePreset}
+        showLabel={true}
+        testId="preview-export-preset"
+      />
+
+      {warningText ? (
+        <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-muted-foreground">
+          {warningText}
+        </div>
+      ) : null}
+
+      {infoText ? (
+        <div className="text-xs text-muted-foreground">{infoText}</div>
+      ) : null}
+
+      <Button
+        className="w-full"
+        size="lg"
+        disabled={!canExport}
+        onClick={onExport}
+      >
+        <Download className="mr-2 size-4" />
+        Export
+      </Button>
+    </div>
   );
 }

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+function Accordion({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return (
+    <AccordionPrimitive.Root
+      data-slot="accordion"
+      className={cn("w-full", className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn(
+        "group rounded-xl border border-border/70 bg-card/40",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex w-full flex-1 items-center justify-between gap-3 rounded-xl px-4 py-3 text-left outline-none transition-[background-color,border-color,color,box-shadow] duration-200 ease-out focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-accent/50 data-[state=open]:text-foreground data-[state=open]:shadow-sm hover:bg-accent/30 [&[data-state=open]>svg]:rotate-180",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDown className="mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform duration-200 ease-out group-data-[state=open]:text-foreground" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className={cn("overflow-hidden text-sm", className)}
+      {...props}
+    >
+      <div className="px-4 pb-5 pt-3">{children}</div>
+    </AccordionPrimitive.Content>
+  );
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -85,6 +85,10 @@ Request body:
   "iconColor": "#ffffff",
   "size": 128,
   "padding": 8,
+  "cornerRadius": 0,
+  "borderEnabled": false,
+  "borderColor": "#ffffff",
+  "borderWidth": 6,
   "outputSize": 128,
   "zendeskLocationMode": false,
   "filename": "logo.svg"
@@ -98,8 +102,17 @@ Rules:
 - `iconColor`: `#RRGGBB`
 - `size`: integer `48..300`
 - `padding`: optional `-200..200` (default `8`)
+- `cornerRadius`: optional number `0..100` (default `0`)
+- `borderEnabled`: optional boolean (default `false`)
+- `borderColor`: optional `#RRGGBB` (default `#ffffff`)
+- `borderWidth`: optional number `0..64` (default `6`)
 - `outputSize`: optional integer `16..4096`
 - `zendeskLocationMode`: optional boolean
+
+Notes:
+
+- Border and corner radius apply to opaque assets/backgrounds.
+- `zendeskLocationMode=true` keeps location SVGs transparent, ignoring background shape and border.
 
 Linear gradient background:
 

--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -111,7 +111,10 @@ test.describe("Export Flow", () => {
   });
 
   test("favicon bundle shows an ico preview thumbnail", async ({ page }) => {
-    const presetSelector = page.getByRole("combobox").nth(2);
+    const presetSelector = page
+      .getByTestId("preview-export-preset")
+      .getByRole("combobox")
+      .first();
     await expect(presetSelector).toBeVisible();
 
     await presetSelector.click();

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.15",
+    "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/src/components/CanvasControlsPane.tsx
+++ b/src/components/CanvasControlsPane.tsx
@@ -14,9 +14,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import {
   Library,
   Layers,
@@ -25,18 +29,17 @@ import {
   Image as ImageIcon,
   PenTool,
   Settings,
-  AlertTriangle,
+  Palette,
+  Sparkles,
 } from "lucide-react";
 import { BackgroundControls } from "./BackgroundControls";
-import { ExportPresetSelector } from "./ExportPresetSelector";
-import { ExportPresetEditor } from "./ExportPresetEditor";
 import { StylePresetSelector } from "./StylePresetSelector";
 import { StylePresetEditor } from "./StylePresetEditor";
 import { PresetSettingsModal } from "./PresetSettingsModal";
 import { usePresets } from "@/src/hooks/use-presets";
 import { ICON_PACKS, type IconPack } from "@/src/constants/app";
 import type { BackgroundValue } from "@/src/utils/gradients";
-import type { ExportPreset, StylePreset } from "@/src/types/preset";
+import type { StylePreset } from "@/src/types/preset";
 import { useRestriction } from "@/src/contexts/RestrictionContext";
 import { RestrictedStyleSelector } from "./RestrictedStyleSelector";
 import type { RestrictedStyle } from "@/src/types/restriction";
@@ -62,15 +65,12 @@ export function CanvasControlsPane({
     isRestricted,
     allowedStyles,
     isIconPackAllowed,
-    allowedExportPresets,
     isLoading: isRestrictionLoading,
   } = useRestriction();
 
   // Presets hook
   const {
     exportPresets,
-    selectedExportPresetId,
-    selectExportPreset,
     createExportPreset,
     updateExportPreset,
     deleteExportPreset,
@@ -87,50 +87,14 @@ export function CanvasControlsPane({
     hasCustomStylePresets,
   } = usePresets();
 
-  // Export preset editor state
-  const [showExportEditor, setShowExportEditor] = React.useState(false);
-  const [editingExportPreset, setEditingExportPreset] = React.useState<
-    ExportPreset | undefined
-  >();
-
   // Style preset editor state
   const [showStyleEditor, setShowStyleEditor] = React.useState(false);
   const [editingStylePreset, setEditingStylePreset] = React.useState<
     StylePreset | undefined
   >();
-
-  // Determine the effective presets list (restricted or all)
-  const effectiveExportPresets = allowedExportPresets ?? exportPresets;
-
-  // Determine the actual selected preset from the effective list
-  const actualSelectedExportPreset = React.useMemo(() => {
-    return effectiveExportPresets.find((p) => p.id === selectedExportPresetId);
-  }, [effectiveExportPresets, selectedExportPresetId]);
-
-  // Check if selected export preset has SVG variants (canvas doesn't support SVG)
-  const hasSvgVariants = React.useMemo(() => {
-    if (!actualSelectedExportPreset) return false;
-    return actualSelectedExportPreset.variants.some((v) => v.format === "svg");
-  }, [actualSelectedExportPreset]);
-
-  // Auto-select first allowed export preset if current is not allowed
-  React.useEffect(() => {
-    if (!isRestricted || !allowedExportPresets) return;
-
-    // Check if current preset is in the allowed list
-    const isCurrentAllowed = allowedExportPresets.some(
-      (p) => p.id === selectedExportPresetId
-    );
-
-    if (!isCurrentAllowed && allowedExportPresets.length > 0) {
-      selectExportPreset(allowedExportPresets[0].id);
-    }
-  }, [
-    isRestricted,
-    allowedExportPresets,
-    selectedExportPresetId,
-    selectExportPreset,
-  ]);
+  const [openSection, setOpenSection] = React.useState<string | undefined>(
+    "colors"
+  );
 
   // Handle applying a style preset
   const handleApplyStylePreset = React.useCallback(
@@ -156,28 +120,6 @@ export function CanvasControlsPane({
     [onBackgroundColorChange, onApplyIconColor]
   );
 
-  // Export preset handlers
-  const handleCreateExportPreset = () => {
-    setEditingExportPreset(undefined);
-    setShowExportEditor(true);
-  };
-
-  const handleEditExportPreset = (preset: ExportPreset) => {
-    setEditingExportPreset(preset);
-    setShowExportEditor(true);
-  };
-
-  const handleSaveExportPreset = (
-    preset: Omit<ExportPreset, "id" | "isBuiltIn" | "createdAt">
-  ) => {
-    if (editingExportPreset) {
-      updateExportPreset(editingExportPreset.id, preset);
-    } else {
-      const newPreset = createExportPreset(preset);
-      selectExportPreset(newPreset.id);
-    }
-  };
-
   // Style preset handlers
   const handleCreateStylePreset = () => {
     setEditingStylePreset(undefined);
@@ -194,6 +136,12 @@ export function CanvasControlsPane({
   ) => {
     if (editingStylePreset) {
       updateStylePreset(editingStylePreset.id, preset);
+      if (selectedStylePresetId === editingStylePreset.id) {
+        handleApplyStylePreset({
+          ...editingStylePreset,
+          ...preset,
+        });
+      }
     } else {
       const newPreset = createStylePreset(preset);
       selectStylePreset(newPreset.id);
@@ -232,168 +180,144 @@ export function CanvasControlsPane({
         ) : null}
       </CardHeader>
       <CardContent className="flex flex-1 flex-col gap-4 overflow-y-auto">
-        {/* Source Selector */}
         <div className="space-y-2">
-          <Label htmlFor="source-select">Source</Label>
-          <Select value={selectedPack} onValueChange={handlePackChange}>
-            <SelectTrigger id="source-select" className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {isIconPackAllowed(ICON_PACKS.ALL) && (
-                <SelectItem value={ICON_PACKS.ALL}>
-                  <span className="flex items-center gap-2">
-                    <Layers className="size-4" />
-                    All Icons
-                  </span>
-                </SelectItem>
-              )}
-              {isIconPackAllowed(ICON_PACKS.GARDEN) && (
-                <SelectItem value={ICON_PACKS.GARDEN}>
-                  <span className="flex items-center gap-2">
-                    <Library className="size-4" />
-                    Garden
-                  </span>
-                </SelectItem>
-              )}
-              {isIconPackAllowed(ICON_PACKS.FEATHER) && (
-                <SelectItem value={ICON_PACKS.FEATHER}>
-                  <span className="flex items-center gap-2">
-                    <Library className="size-4" />
-                    Feather
-                  </span>
-                </SelectItem>
-              )}
-              {isIconPackAllowed(ICON_PACKS.REMIXICON) && (
-                <SelectItem value={ICON_PACKS.REMIXICON}>
-                  <span className="flex items-center gap-2">
-                    <Library className="size-4" />
-                    RemixIcon
-                  </span>
-                </SelectItem>
-              )}
-              {isIconPackAllowed(ICON_PACKS.EMOJI) && (
-                <SelectItem value={ICON_PACKS.EMOJI}>
-                  <span className="flex items-center gap-2">
-                    <Smile className="size-4" />
-                    Emoji
-                  </span>
-                </SelectItem>
-              )}
-              {isIconPackAllowed(ICON_PACKS.CUSTOM_SVG) && (
-                <SelectItem value={ICON_PACKS.CUSTOM_SVG}>
-                  <span className="flex items-center gap-2">
-                    <Upload className="size-4" />
-                    Custom SVG
-                  </span>
-                </SelectItem>
-              )}
-              {isIconPackAllowed(ICON_PACKS.CUSTOM_IMAGE) && (
-                <SelectItem value={ICON_PACKS.CUSTOM_IMAGE}>
-                  <span className="flex items-center gap-2">
-                    <ImageIcon className="size-4" />
-                    Custom Image
-                  </span>
-                </SelectItem>
-              )}
-              {isIconPackAllowed(ICON_PACKS.CANVAS) && (
-                <SelectItem value={ICON_PACKS.CANVAS}>
-                  <span className="flex items-center gap-2">
-                    <PenTool className="size-4" />
-                    Canvas Editor
-                  </span>
-                </SelectItem>
-              )}
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">
-            Select a different source to exit canvas mode.
-          </p>
+          <div className="flex items-center gap-3">
+            <div className="rounded-lg bg-accent/55 p-2 text-accent-foreground">
+              <Layers className="h-4 w-4" />
+            </div>
+            <div className="min-w-0">
+              <div className="text-sm font-semibold">Source</div>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="source-select">Source</Label>
+            <Select value={selectedPack} onValueChange={handlePackChange}>
+              <SelectTrigger id="source-select" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {isIconPackAllowed(ICON_PACKS.ALL) && (
+                  <SelectItem value={ICON_PACKS.ALL}>
+                    <span className="flex items-center gap-2">
+                      <Layers className="size-4" />
+                      All Icons
+                    </span>
+                  </SelectItem>
+                )}
+                {isIconPackAllowed(ICON_PACKS.GARDEN) && (
+                  <SelectItem value={ICON_PACKS.GARDEN}>
+                    <span className="flex items-center gap-2">
+                      <Library className="size-4" />
+                      Garden
+                    </span>
+                  </SelectItem>
+                )}
+                {isIconPackAllowed(ICON_PACKS.FEATHER) && (
+                  <SelectItem value={ICON_PACKS.FEATHER}>
+                    <span className="flex items-center gap-2">
+                      <Library className="size-4" />
+                      Feather
+                    </span>
+                  </SelectItem>
+                )}
+                {isIconPackAllowed(ICON_PACKS.REMIXICON) && (
+                  <SelectItem value={ICON_PACKS.REMIXICON}>
+                    <span className="flex items-center gap-2">
+                      <Library className="size-4" />
+                      RemixIcon
+                    </span>
+                  </SelectItem>
+                )}
+                {isIconPackAllowed(ICON_PACKS.EMOJI) && (
+                  <SelectItem value={ICON_PACKS.EMOJI}>
+                    <span className="flex items-center gap-2">
+                      <Smile className="size-4" />
+                      Emoji
+                    </span>
+                  </SelectItem>
+                )}
+                {isIconPackAllowed(ICON_PACKS.CUSTOM_SVG) && (
+                  <SelectItem value={ICON_PACKS.CUSTOM_SVG}>
+                    <span className="flex items-center gap-2">
+                      <Upload className="size-4" />
+                      Custom SVG
+                    </span>
+                  </SelectItem>
+                )}
+                {isIconPackAllowed(ICON_PACKS.CUSTOM_IMAGE) && (
+                  <SelectItem value={ICON_PACKS.CUSTOM_IMAGE}>
+                    <span className="flex items-center gap-2">
+                      <ImageIcon className="size-4" />
+                      Custom Image
+                    </span>
+                  </SelectItem>
+                )}
+                {isIconPackAllowed(ICON_PACKS.CANVAS) && (
+                  <SelectItem value={ICON_PACKS.CANVAS}>
+                    <span className="flex items-center gap-2">
+                      <PenTool className="size-4" />
+                      Canvas Editor
+                    </span>
+                  </SelectItem>
+                )}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Select a different source to exit canvas mode.
+            </p>
+          </div>
         </div>
 
-        <Separator />
+        <Accordion
+          type="single"
+          collapsible
+          value={openSection}
+          onValueChange={setOpenSection}
+          className="space-y-3"
+        >
+          {!isRestrictionLoading && !isRestricted ? (
+            <AccordionItem value="style">
+              <AccordionTrigger>
+                <AccordionSectionHeader icon={Sparkles} title="Style Presets" />
+              </AccordionTrigger>
+              <AccordionContent>
+                <StylePresetSelector
+                  presets={stylePresets}
+                  selectedPresetId={selectedStylePresetId}
+                  onSelectPreset={selectStylePreset}
+                  onApplyPreset={handleApplyStylePreset}
+                  onCreatePreset={handleCreateStylePreset}
+                  onEditPreset={handleEditStylePreset}
+                  onDeletePreset={deleteStylePreset}
+                />
+              </AccordionContent>
+            </AccordionItem>
+          ) : null}
 
-        {/* Export Preset Selection */}
-        <ExportPresetSelector
-          presets={effectiveExportPresets}
-          selectedPresetId={selectedExportPresetId}
-          onSelectPreset={selectExportPreset}
-          onCreatePreset={
-            !isRestrictionLoading && !isRestricted
-              ? handleCreateExportPreset
-              : undefined
-          }
-          onEditPreset={
-            !isRestrictionLoading && !isRestricted
-              ? handleEditExportPreset
-              : undefined
-          }
-          onDeletePreset={
-            !isRestrictionLoading && !isRestricted
-              ? deleteExportPreset
-              : undefined
-          }
-        />
-
-        {/* SVG Warning for Canvas Mode */}
-        {hasSvgVariants && (
-          <Alert
-            variant="default"
-            className="border-amber-500/50 bg-amber-500/10"
-          >
-            <AlertTriangle className="h-4 w-4 text-amber-500" />
-            <AlertDescription className="text-xs">
-              Canvas mode only exports raster formats. SVG files in this preset
-              will be skipped.
-            </AlertDescription>
-          </Alert>
-        )}
-
-        <Separator />
-
-        {/* Style Controls - different UI for restricted vs normal mode */}
-        {!isRestrictionLoading && isRestricted ? (
-          /* Restricted mode - show simplified style selector with color palette */
-          <RestrictedStyleSelector
-            styles={allowedStyles}
-            currentBackground={backgroundColor}
-            currentIconColor="#ffffff"
-            onStyleSelect={handleApplyRestrictedStyle}
-            showColorPalette={true}
-            onColorSelect={onApplyIconColor}
-          />
-        ) : (
-          <>
-            {/* Style Preset Selection */}
-            <StylePresetSelector
-              presets={stylePresets}
-              selectedPresetId={selectedStylePresetId}
-              onSelectPreset={selectStylePreset}
-              onApplyPreset={handleApplyStylePreset}
-              onCreatePreset={handleCreateStylePreset}
-              onEditPreset={handleEditStylePreset}
-              onDeletePreset={deleteStylePreset}
-            />
-
-            <Separator />
-
-            {/* Background Controls */}
-            <BackgroundControls
-              value={backgroundColor}
-              onChange={onBackgroundColorChange}
-            />
-          </>
-        )}
+          <AccordionItem value="colors">
+            <AccordionTrigger>
+              <AccordionSectionHeader icon={Palette} title="Canvas Colors" />
+            </AccordionTrigger>
+            <AccordionContent>
+              {!isRestrictionLoading && isRestricted ? (
+                <RestrictedStyleSelector
+                  styles={allowedStyles}
+                  currentBackground={backgroundColor}
+                  currentIconColor="#ffffff"
+                  onStyleSelect={handleApplyRestrictedStyle}
+                  showColorPalette={true}
+                  onColorSelect={onApplyIconColor}
+                />
+              ) : (
+                <BackgroundControls
+                  value={backgroundColor}
+                  onChange={onBackgroundColorChange}
+                />
+              )}
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </CardContent>
-
-      {/* Export Preset Editor Modal */}
-      <ExportPresetEditor
-        open={showExportEditor}
-        onOpenChange={setShowExportEditor}
-        preset={editingExportPreset}
-        onSave={handleSaveExportPreset}
-        mode={editingExportPreset ? "edit" : "create"}
-      />
 
       {/* Style Preset Editor Modal */}
       <StylePresetEditor
@@ -404,5 +328,26 @@ export function CanvasControlsPane({
         mode={editingStylePreset ? "edit" : "create"}
       />
     </Card>
+  );
+}
+
+interface AccordionSectionHeaderProps {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+}
+
+function AccordionSectionHeader({
+  icon: Icon,
+  title,
+}: AccordionSectionHeaderProps) {
+  return (
+    <div className="flex min-w-0 items-start gap-3">
+      <div className="rounded-lg bg-accent/55 p-2 text-accent-foreground">
+        <Icon className="h-4 w-4" />
+      </div>
+      <div className="min-w-0">
+        <div className="text-sm font-semibold">{title}</div>
+      </div>
+    </div>
   );
 }

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,8 +1,9 @@
 /**
- * Reusable color picker component with hex input and recent colors
+ * Reusable compact color picker with optional swatch tray
  */
 
 import * as React from "react";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -11,19 +12,21 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Info } from "lucide-react";
+import { ChevronDown, ChevronUp, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   getRecentColors,
   addColorToHistory,
   type ColorType,
 } from "@/src/utils/color-history";
-import { useDebouncedValue } from "@/src/hooks/use-debounced-value";
+import { useDebouncedColorState } from "@/src/hooks/use-debounced-color-state";
 import type { ColorPaletteEntry } from "@/src/types/preset";
+
+const FULL_HEX_PATTERN = /^#[0-9A-Fa-f]{6}$/;
 
 export interface ColorPickerProps {
   id: string;
-  label: string;
+  label?: string;
   value: string;
   onChange: (value: string) => void;
   className?: string;
@@ -36,6 +39,17 @@ export interface ColorPickerProps {
    * Used in restricted mode to limit color choices.
    */
   restrictedMode?: boolean;
+  /**
+   * Controlled expansion state for the swatch tray.
+   * If undefined, expansion is managed internally.
+   */
+  expanded?: boolean;
+  /** Controlled expansion callback for grouped contexts. */
+  onExpandedChange?: (expanded: boolean) => void;
+}
+
+function colorInputValue(value: string): string {
+  return FULL_HEX_PATTERN.test(value) ? value : "#000000";
 }
 
 export function ColorPicker({
@@ -48,90 +62,121 @@ export function ColorPicker({
   isCustomSvg = false,
   paletteColors,
   restrictedMode = false,
+  expanded,
+  onExpandedChange,
 }: ColorPickerProps) {
   const [recentColors, setRecentColors] = React.useState<string[]>([]);
+  const [internalExpanded, setInternalExpanded] = React.useState(false);
 
-  // Local state for immediate UI updates
-  const [localValue, setLocalValue] = React.useState(value);
-  const lastPropValueRef = React.useRef(value);
+  const {
+    localValue,
+    debouncedValue,
+    setColorValue,
+    setHexValue,
+    commitValue,
+  } = useDebouncedColorState({
+    value,
+    onChange,
+  });
 
-  // Debounce value changes to avoid excessive re-renders while typing/adjusting
-  const debouncedLocalValue = useDebouncedValue(localValue, 300);
-
-  // Load recent colors on mount and when colorType changes
   React.useEffect(() => {
     if (colorType) {
       setRecentColors(getRecentColors(colorType));
     }
   }, [colorType]);
 
-  // Update parent when debounced value changes (but only if it's different from prop)
   React.useEffect(() => {
-    if (debouncedLocalValue !== lastPropValueRef.current) {
-      lastPropValueRef.current = debouncedLocalValue;
-      onChange(debouncedLocalValue);
-    }
-  }, [debouncedLocalValue, onChange]);
-
-  // Sync local state when prop changes externally
-  React.useEffect(() => {
-    if (value !== lastPropValueRef.current) {
-      lastPropValueRef.current = value;
-      setLocalValue(value);
-    }
-  }, [value]);
-
-  // Save color to history when debounced value changes (only if it's a valid hex color)
-  React.useEffect(() => {
-    if (
-      colorType &&
-      debouncedLocalValue &&
-      /^#[0-9A-Fa-f]{6}$/.test(debouncedLocalValue)
-    ) {
-      addColorToHistory(colorType, debouncedLocalValue);
-      // Refresh recent colors to show the updated list
+    if (colorType && debouncedValue && FULL_HEX_PATTERN.test(debouncedValue)) {
+      addColorToHistory(colorType, debouncedValue);
       setRecentColors(getRecentColors(colorType));
     }
-  }, [debouncedLocalValue, colorType]);
+  }, [debouncedValue, colorType]);
 
-  const handleColorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLocalValue(e.target.value);
-  };
+  const hasPresetColors = Boolean(paletteColors?.length);
+  const hasRecentColors = Boolean(colorType && recentColors.length > 0);
+  const hasTrayContent = hasPresetColors || hasRecentColors;
+  const showSectionLabels = hasPresetColors && hasRecentColors;
 
-  const handleHexChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const hex = e.target.value;
-    // Basic validation - allow partial input
-    if (hex === "" || /^#[0-9A-Fa-f]{0,6}$/.test(hex)) {
-      setLocalValue(hex);
+  const isExpanded = expanded ?? internalExpanded;
+  const setExpanded = React.useCallback(
+    (nextExpanded: boolean) => {
+      if (expanded === undefined) {
+        setInternalExpanded(nextExpanded);
+      }
+      onExpandedChange?.(nextExpanded);
+    },
+    [expanded, onExpandedChange]
+  );
+
+  React.useEffect(() => {
+    if (!hasTrayContent && internalExpanded && expanded === undefined) {
+      setInternalExpanded(false);
     }
+  }, [expanded, hasTrayContent, internalExpanded]);
+
+  const handleSwatchSelect = (color: string) => {
+    commitValue(color);
   };
 
-  const handleRecentColorClick = (color: string) => {
-    setLocalValue(color);
+  const renderLabelRow = () => {
+    if (!label && !isCustomSvg) {
+      return null;
+    }
+
+    return (
+      <div className="flex items-center gap-2">
+        {label ? <Label htmlFor={id}>{label}</Label> : null}
+        {isCustomSvg ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Info className="size-3.5 text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="max-w-xs">
+                  Color customization replaces all{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                    fill
+                  </code>{" "}
+                  and{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                    stroke
+                  </code>{" "}
+                  colors in the SVG, except for{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                    none
+                  </code>
+                  ,{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                    transparent
+                  </code>
+                  , and gradient/pattern references.
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : null}
+      </div>
+    );
   };
 
-  // Restricted mode: only show palette color swatches
-  if (restrictedMode && paletteColors && paletteColors.length > 0) {
+  const swatchBaseClass =
+    "size-7 rounded-md border border-input transition-colors hover:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1";
+
+  if (restrictedMode && hasPresetColors) {
     return (
       <div className={cn("space-y-2", className)}>
-        <Label>{label}</Label>
+        {renderLabelRow()}
         <TooltipProvider>
-          <div className="flex gap-2 flex-wrap">
-            {paletteColors.map((entry) => (
+          <div className="flex flex-wrap gap-1.5">
+            {paletteColors!.map((entry) => (
               <Tooltip key={entry.id}>
                 <TooltipTrigger asChild>
                   <button
                     type="button"
-                    onClick={() => {
-                      setLocalValue(entry.color);
-                      // In restricted mode, update immediately
-                      lastPropValueRef.current = entry.color;
-                      onChange(entry.color);
-                    }}
+                    onClick={() => handleSwatchSelect(entry.color)}
                     className={cn(
-                      "h-8 w-8 rounded-md border-2 transition-all",
-                      "hover:scale-110 hover:ring-2 hover:ring-ring",
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      swatchBaseClass,
                       localValue.toLowerCase() === entry.color.toLowerCase() &&
                         "ring-2 ring-primary ring-offset-1"
                     )}
@@ -141,7 +186,7 @@ export function ColorPicker({
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>{entry.name}</p>
-                  <p className="text-xs text-muted-foreground font-mono">
+                  <p className="font-mono text-xs text-muted-foreground">
                     {entry.color}
                   </p>
                 </TooltipContent>
@@ -155,115 +200,109 @@ export function ColorPicker({
 
   return (
     <div className={cn("space-y-2", className)}>
+      {renderLabelRow()}
+
       <div className="flex items-center gap-2">
-        <Label htmlFor={id}>{label}</Label>
-        {isCustomSvg && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Info className="size-3.5 text-muted-foreground" />
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="max-w-xs">
-                  Color customization replaces all{" "}
-                  <code className="text-xs bg-muted px-1 py-0.5 rounded">
-                    fill
-                  </code>{" "}
-                  and{" "}
-                  <code className="text-xs bg-muted px-1 py-0.5 rounded">
-                    stroke
-                  </code>{" "}
-                  colors in the SVG, except for{" "}
-                  <code className="text-xs bg-muted px-1 py-0.5 rounded">
-                    none
-                  </code>
-                  ,{" "}
-                  <code className="text-xs bg-muted px-1 py-0.5 rounded">
-                    transparent
-                  </code>
-                  , and gradient/pattern references.
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
-      </div>
-      <div className="flex gap-2">
         <input
           id={id}
           type="color"
-          value={localValue}
-          onChange={handleColorChange}
-          className="h-10 w-20 cursor-pointer rounded-md border"
+          value={colorInputValue(localValue)}
+          onChange={(e) => setColorValue(e.target.value)}
+          className="h-9 w-9 cursor-pointer rounded-md border border-input bg-background p-0"
+          aria-label={label || "Pick a color"}
         />
         <Input
           id={`${id}-hex`}
           value={localValue}
-          onChange={handleHexChange}
-          className="flex-1 font-mono"
+          onChange={(e) => setHexValue(e.target.value)}
+          className="h-9 flex-1 px-2.5 font-mono text-xs sm:text-sm"
           placeholder="#ffffff"
           maxLength={7}
         />
+        {hasTrayContent ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            onClick={() => setExpanded(!isExpanded)}
+            aria-expanded={isExpanded}
+            aria-controls={`${id}-swatch-tray`}
+            aria-label={
+              isExpanded ? "Hide color swatches" : "Show color swatches"
+            }
+          >
+            {isExpanded ? <ChevronUp /> : <ChevronDown />}
+          </Button>
+        ) : null}
       </div>
-      {paletteColors && paletteColors.length > 0 && (
-        <div className="space-y-1.5">
-          <p className="text-xs text-muted-foreground">Preset colors</p>
-          <TooltipProvider>
-            <div className="flex gap-2 flex-wrap">
-              {paletteColors.map((entry) => (
-                <Tooltip key={entry.id}>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={() => handleRecentColorClick(entry.color)}
-                      className={cn(
-                        "h-8 w-8 rounded-md border-2 transition-all",
-                        "hover:scale-110 hover:ring-2 hover:ring-ring",
-                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                        localValue.toLowerCase() ===
-                          entry.color.toLowerCase() &&
-                          "ring-2 ring-primary ring-offset-1"
-                      )}
-                      style={{ backgroundColor: entry.color }}
-                      aria-label={`Select ${entry.name} (${entry.color})`}
-                    />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>{entry.name}</p>
-                    <p className="text-xs text-muted-foreground font-mono">
-                      {entry.color}
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              ))}
+
+      {hasTrayContent && isExpanded ? (
+        <div
+          id={`${id}-swatch-tray`}
+          className="space-y-2 rounded-md border border-border/70 bg-muted/20 p-2"
+        >
+          {hasPresetColors ? (
+            <div className="space-y-1.5">
+              {showSectionLabels ? (
+                <p className="text-xs text-muted-foreground">Preset colors</p>
+              ) : null}
+              <TooltipProvider>
+                <div className="flex flex-wrap gap-1.5">
+                  {paletteColors!.map((entry) => (
+                    <Tooltip key={entry.id}>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => handleSwatchSelect(entry.color)}
+                          className={cn(
+                            swatchBaseClass,
+                            localValue.toLowerCase() ===
+                              entry.color.toLowerCase() &&
+                              "ring-2 ring-primary ring-offset-1"
+                          )}
+                          style={{ backgroundColor: entry.color }}
+                          aria-label={`Select ${entry.name} (${entry.color})`}
+                        />
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>{entry.name}</p>
+                        <p className="font-mono text-xs text-muted-foreground">
+                          {entry.color}
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  ))}
+                </div>
+              </TooltipProvider>
             </div>
-          </TooltipProvider>
+          ) : null}
+
+          {hasRecentColors ? (
+            <div className="space-y-1.5">
+              {showSectionLabels ? (
+                <p className="text-xs text-muted-foreground">Recent colors</p>
+              ) : null}
+              <div className="flex flex-wrap gap-1.5">
+                {recentColors.map((color) => (
+                  <button
+                    key={color}
+                    type="button"
+                    onClick={() => handleSwatchSelect(color)}
+                    className={cn(
+                      swatchBaseClass,
+                      localValue.toLowerCase() === color.toLowerCase() &&
+                        "ring-2 ring-primary ring-offset-1"
+                    )}
+                    style={{ backgroundColor: color }}
+                    aria-label={`Select color ${color}`}
+                    title={color}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
         </div>
-      )}
-      {colorType && recentColors.length > 0 && (
-        <div className="space-y-1.5">
-          <p className="text-xs text-muted-foreground">Recent colors</p>
-          <div className="flex gap-2 flex-wrap">
-            {recentColors.map((color) => (
-              <button
-                key={color}
-                type="button"
-                onClick={() => handleRecentColorClick(color)}
-                className={cn(
-                  "h-8 w-8 rounded-md border-2 transition-all",
-                  "hover:scale-110 hover:ring-2 hover:ring-ring",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                  localValue.toLowerCase() === color.toLowerCase() &&
-                    "ring-2 ring-primary ring-offset-1"
-                )}
-                style={{ backgroundColor: color }}
-                aria-label={`Select color ${color}`}
-                title={color}
-              />
-            ))}
-          </div>
-        </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/components/DebouncedColorInput.tsx
+++ b/src/components/DebouncedColorInput.tsx
@@ -3,9 +3,8 @@
  * Provides immediate UI feedback while debouncing parent updates
  */
 
-import * as React from "react";
 import { Input } from "@/components/ui/input";
-import { useDebouncedValue } from "@/src/hooks/use-debounced-value";
+import { useDebouncedColorState } from "@/src/hooks/use-debounced-color-state";
 
 /** Default debounce delay in milliseconds */
 const DEFAULT_DEBOUNCE_DELAY = 300;
@@ -36,43 +35,14 @@ export function DebouncedColorInput({
   ariaLabel,
   debounceDelay = DEFAULT_DEBOUNCE_DELAY,
   showTextInput = true,
-  colorInputClassName = "h-8 w-10 cursor-pointer rounded-md border flex-shrink-0",
-  textInputClassName = "w-24 font-mono text-xs",
+  colorInputClassName = "h-9 w-9 cursor-pointer rounded-md border border-input bg-background p-0",
+  textInputClassName = "h-9 w-24 px-2.5 font-mono text-xs",
 }: DebouncedColorInputProps) {
-  // Local state for immediate UI updates
-  const [localValue, setLocalValue] = React.useState(value);
-  const lastPropValueRef = React.useRef(value);
-
-  // Debounce value changes to avoid excessive re-renders
-  const debouncedLocalValue = useDebouncedValue(localValue, debounceDelay);
-
-  // Update parent when debounced value changes (but only if it's different from prop)
-  React.useEffect(() => {
-    if (debouncedLocalValue !== lastPropValueRef.current) {
-      lastPropValueRef.current = debouncedLocalValue;
-      onChange(debouncedLocalValue);
-    }
-  }, [debouncedLocalValue, onChange]);
-
-  // Sync local state when prop changes externally
-  React.useEffect(() => {
-    if (value !== lastPropValueRef.current) {
-      lastPropValueRef.current = value;
-      setLocalValue(value);
-    }
-  }, [value]);
-
-  const handleColorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLocalValue(e.target.value);
-  };
-
-  const handleHexChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const hex = e.target.value;
-    // Basic validation - allow partial input
-    if (hex === "" || /^#[0-9A-Fa-f]{0,6}$/.test(hex)) {
-      setLocalValue(hex);
-    }
-  };
+  const { localValue, setColorValue, setHexValue } = useDebouncedColorState({
+    value,
+    onChange,
+    debounceDelay,
+  });
 
   if (!showTextInput) {
     return (
@@ -80,7 +50,7 @@ export function DebouncedColorInput({
         id={id}
         type="color"
         value={localValue}
-        onChange={handleColorChange}
+        onChange={(e) => setColorValue(e.target.value)}
         className={colorInputClassName}
         aria-label={ariaLabel}
       />
@@ -93,13 +63,13 @@ export function DebouncedColorInput({
         id={id}
         type="color"
         value={localValue}
-        onChange={handleColorChange}
+        onChange={(e) => setColorValue(e.target.value)}
         className={colorInputClassName}
         aria-label={ariaLabel}
       />
       <Input
         value={localValue}
-        onChange={handleHexChange}
+        onChange={(e) => setHexValue(e.target.value)}
         placeholder="#ffffff"
         className={textInputClassName}
         maxLength={7}

--- a/src/components/ExportPresetSelector.tsx
+++ b/src/components/ExportPresetSelector.tsx
@@ -32,6 +32,7 @@ export interface ExportPresetSelectorProps {
   onDeletePreset?: (id: string) => void;
   showLabel?: boolean;
   className?: string;
+  testId?: string;
 }
 
 export function ExportPresetSelector({
@@ -43,15 +44,16 @@ export function ExportPresetSelector({
   onDeletePreset,
   showLabel = true,
   className,
+  testId,
 }: ExportPresetSelectorProps) {
   const selectedPreset = presets.find((p) => p.id === selectedPresetId);
   const builtInPresets = presets.filter((p) => p.isBuiltIn);
   const customPresets = presets.filter((p) => !p.isBuiltIn);
 
   return (
-    <div className={className}>
+    <div className={className} data-testid={testId}>
       {showLabel && (
-        <div className="flex items-center gap-2 mb-2">
+        <div className="mb-2 flex items-center gap-2">
           <Package className="h-4 w-4 text-muted-foreground" />
           <Label className="text-sm font-medium">Export Preset</Label>
         </div>
@@ -59,7 +61,7 @@ export function ExportPresetSelector({
 
       <div className="flex items-center gap-2">
         <Select value={selectedPresetId} onValueChange={onSelectPreset}>
-          <SelectTrigger className="flex-1">
+          <SelectTrigger className="h-11 flex-1 rounded-lg border-border/70 bg-background/70">
             <SelectValue placeholder="Select preset...">
               {selectedPreset?.name}
             </SelectValue>
@@ -115,7 +117,7 @@ export function ExportPresetSelector({
                   variant="outline"
                   size="icon"
                   onClick={onCreatePreset}
-                  className="h-9 w-9"
+                  className="h-11 w-11 rounded-lg"
                 >
                   <Plus className="h-4 w-4" />
                 </Button>
@@ -133,7 +135,7 @@ export function ExportPresetSelector({
                       variant="outline"
                       size="icon"
                       onClick={() => onEditPreset(selectedPreset)}
-                      className="h-9 w-9"
+                      className="h-11 w-11 rounded-lg"
                     >
                       <Edit2 className="h-4 w-4" />
                     </Button>
@@ -149,7 +151,7 @@ export function ExportPresetSelector({
                       variant="outline"
                       size="icon"
                       onClick={() => onDeletePreset(selectedPreset.id)}
-                      className="h-9 w-9 text-destructive hover:text-destructive"
+                      className="h-11 w-11 rounded-lg text-destructive hover:text-destructive"
                     >
                       <Trash2 className="h-4 w-4" />
                     </Button>
@@ -161,13 +163,6 @@ export function ExportPresetSelector({
           )}
         </div>
       </div>
-
-      {/* Preset description */}
-      {selectedPreset && (
-        <p className="mt-2 text-xs text-muted-foreground">
-          {selectedPreset.description}
-        </p>
-      )}
     </div>
   );
 }

--- a/src/components/LinearGradientEditor.tsx
+++ b/src/components/LinearGradientEditor.tsx
@@ -22,6 +22,9 @@ export function LinearGradientEditor({
 }: LinearGradientEditorProps) {
   // Local state for immediate UI updates
   const [localGradient, setLocalGradient] = React.useState(gradient);
+  const [expandedPickerId, setExpandedPickerId] = React.useState<string | null>(
+    null
+  );
   const lastPropGradientRef = React.useRef(gradient);
 
   // Debounce gradient changes to avoid excessive re-renders while adjusting
@@ -83,26 +86,34 @@ export function LinearGradientEditor({
 
         <div className="space-y-3">
           <Label className="text-xs">Colors</Label>
-          {localGradient.stops.map((stop, index) => (
-            <div key={index} className="space-y-2">
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground min-w-[60px]">
-                  {index === 0
-                    ? "From"
-                    : index === localGradient.stops.length - 1
-                      ? "To"
-                      : `Stop ${index + 1}`}
-                </span>
-                <ColorPicker
-                  id={`gradient-stop-${index}`}
-                  label=""
-                  value={stop.color}
-                  onChange={(color) => handleStopColorChange(index, color)}
-                  colorType="background"
-                />
+          {localGradient.stops.map((stop, index) => {
+            const pickerId = `gradient-stop-${index}`;
+
+            return (
+              <div key={index} className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground min-w-[60px]">
+                    {index === 0
+                      ? "From"
+                      : index === localGradient.stops.length - 1
+                        ? "To"
+                        : `Stop ${index + 1}`}
+                  </span>
+                  <ColorPicker
+                    id={pickerId}
+                    value={stop.color}
+                    onChange={(color) => handleStopColorChange(index, color)}
+                    colorType="background"
+                    className="flex-1"
+                    expanded={expandedPickerId === pickerId}
+                    onExpandedChange={(expanded) => {
+                      setExpandedPickerId(expanded ? pickerId : null);
+                    }}
+                  />
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/components/PngPreview.tsx
+++ b/src/components/PngPreview.tsx
@@ -69,6 +69,10 @@ export function PngPreview({
             height: PNG_SPECS.LOGO.height,
             colorOverride,
             originalColor,
+            cornerRadius: state.cornerRadius,
+            borderEnabled: state.borderEnabled,
+            borderColor: state.borderColor,
+            borderWidth: state.borderWidth,
           });
 
           if (cancelled) return;
@@ -84,6 +88,10 @@ export function PngPreview({
             height: PNG_SPECS.LOGO_SMALL.height,
             colorOverride,
             originalColor,
+            cornerRadius: state.cornerRadius,
+            borderEnabled: state.borderEnabled,
+            borderColor: state.borderColor,
+            borderWidth: state.borderWidth,
           });
 
           if (cancelled) return;
@@ -102,6 +110,10 @@ export function PngPreview({
             size: state.iconSize,
             width: PNG_SPECS.LOGO.width,
             height: PNG_SPECS.LOGO.height,
+            cornerRadius: state.cornerRadius,
+            borderEnabled: state.borderEnabled,
+            borderColor: state.borderColor,
+            borderWidth: state.borderWidth,
           });
 
           if (cancelled) return;
@@ -116,6 +128,10 @@ export function PngPreview({
             size: state.iconSize,
             width: PNG_SPECS.LOGO_SMALL.width,
             height: PNG_SPECS.LOGO_SMALL.height,
+            cornerRadius: state.cornerRadius,
+            borderEnabled: state.borderEnabled,
+            borderColor: state.borderColor,
+            borderWidth: state.borderWidth,
           });
 
           if (cancelled) return;

--- a/src/components/PresetPreview.tsx
+++ b/src/components/PresetPreview.tsx
@@ -138,6 +138,10 @@ export function PresetPreview({
                 iconColor: state.iconColor,
                 size: Math.min(variant.width, variant.height),
                 padding: 4,
+                cornerRadius: state.cornerRadius,
+                borderEnabled: state.borderEnabled,
+                borderColor: state.borderColor,
+                borderWidth: state.borderWidth,
               });
               const blob = new Blob([svgString], { type: "image/svg+xml" });
               url = URL.createObjectURL(blob);
@@ -150,6 +154,10 @@ export function PresetPreview({
                 size: state.iconSize,
                 width: variant.width,
                 height: variant.height,
+                cornerRadius: state.cornerRadius,
+                borderEnabled: state.borderEnabled,
+                borderColor: state.borderColor,
+                borderWidth: state.borderWidth,
               });
               url = URL.createObjectURL(blob);
             } else if (isCustomImg && imageDataUrl && iconId) {
@@ -167,6 +175,10 @@ export function PresetPreview({
                 height: variant.height,
                 colorOverride,
                 originalColor,
+                cornerRadius: state.cornerRadius,
+                borderEnabled: state.borderEnabled,
+                borderColor: state.borderColor,
+                borderWidth: state.borderWidth,
               });
               url = URL.createObjectURL(blob);
             } else if (icon) {
@@ -179,6 +191,10 @@ export function PresetPreview({
                   size: state.iconSize,
                   width: variant.width,
                   height: variant.height,
+                  cornerRadius: state.cornerRadius,
+                  borderEnabled: state.borderEnabled,
+                  borderColor: state.borderColor,
+                  borderWidth: state.borderWidth,
                 });
                 url = URL.createObjectURL(blob);
               } else if (
@@ -194,6 +210,10 @@ export function PresetPreview({
                   height: variant.height,
                   format: variant.format,
                   quality: variant.quality,
+                  cornerRadius: state.cornerRadius,
+                  borderEnabled: state.borderEnabled,
+                  borderColor: state.borderColor,
+                  borderWidth: state.borderWidth,
                 });
                 url = URL.createObjectURL(blob);
               }

--- a/src/components/RadialGradientEditor.tsx
+++ b/src/components/RadialGradientEditor.tsx
@@ -22,6 +22,9 @@ export function RadialGradientEditor({
 }: RadialGradientEditorProps) {
   // Local state for immediate UI updates
   const [localGradient, setLocalGradient] = React.useState(gradient);
+  const [expandedPickerId, setExpandedPickerId] = React.useState<string | null>(
+    null
+  );
   const lastPropGradientRef = React.useRef(gradient);
 
   // Debounce gradient changes to avoid excessive re-renders while adjusting
@@ -113,26 +116,34 @@ export function RadialGradientEditor({
 
         <div className="space-y-3">
           <Label className="text-xs">Colors</Label>
-          {localGradient.stops.map((stop, index) => (
-            <div key={index} className="space-y-2">
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground min-w-[60px]">
-                  {index === 0
-                    ? "Center"
-                    : index === localGradient.stops.length - 1
-                      ? "Edge"
-                      : `Stop ${index + 1}`}
-                </span>
-                <ColorPicker
-                  id={`gradient-stop-${index}`}
-                  label=""
-                  value={stop.color}
-                  onChange={(color) => handleStopColorChange(index, color)}
-                  colorType="background"
-                />
+          {localGradient.stops.map((stop, index) => {
+            const pickerId = `gradient-stop-${index}`;
+
+            return (
+              <div key={index} className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground min-w-[60px]">
+                    {index === 0
+                      ? "Center"
+                      : index === localGradient.stops.length - 1
+                        ? "Edge"
+                        : `Stop ${index + 1}`}
+                  </span>
+                  <ColorPicker
+                    id={pickerId}
+                    value={stop.color}
+                    onChange={(color) => handleStopColorChange(index, color)}
+                    colorType="background"
+                    className="flex-1"
+                    expanded={expandedPickerId === pickerId}
+                    onExpandedChange={(expanded) => {
+                      setExpandedPickerId(expanded ? pickerId : null);
+                    }}
+                  />
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/components/StylePresetEditor.tsx
+++ b/src/components/StylePresetEditor.tsx
@@ -16,13 +16,16 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
 import { BackgroundControls } from "./BackgroundControls";
 import { ColorPicker } from "./ColorPicker";
 import { DebouncedColorInput } from "./DebouncedColorInput";
+import { EffectSlider } from "./EffectSlider";
 import type { StylePreset, ColorPaletteEntry } from "@/src/types/preset";
 import type { BackgroundValue } from "@/src/utils/gradients";
 import { KALE_COLORS } from "@/src/utils/gradients";
 import { generateColorPaletteEntryId } from "@/src/utils/preset-storage";
+import { DEFAULT_APPEARANCE } from "@/src/constants/app";
 
 /** Maximum number of colors in a palette */
 const MAX_PALETTE_COLORS = 8;
@@ -64,6 +67,18 @@ export function StylePresetEditor({
   const [iconColor, setIconColor] = React.useState(
     preset?.iconColor || DEFAULT_ICON_COLOR
   );
+  const [cornerRadius, setCornerRadius] = React.useState(
+    preset?.cornerRadius ?? DEFAULT_APPEARANCE.CORNER_RADIUS
+  );
+  const [borderEnabled, setBorderEnabled] = React.useState(
+    preset?.borderEnabled ?? DEFAULT_APPEARANCE.BORDER_ENABLED
+  );
+  const [borderColor, setBorderColor] = React.useState(
+    preset?.borderColor ?? DEFAULT_APPEARANCE.BORDER_COLOR
+  );
+  const [borderWidth, setBorderWidth] = React.useState(
+    preset?.borderWidth ?? DEFAULT_APPEARANCE.BORDER_WIDTH
+  );
   const [colorPalette, setColorPalette] = React.useState<ColorPaletteEntry[]>(
     preset?.colorPalette || []
   );
@@ -74,11 +89,21 @@ export function StylePresetEditor({
       setName(preset.name);
       setBackgroundColor(preset.backgroundColor);
       setIconColor(preset.iconColor);
+      setCornerRadius(preset.cornerRadius ?? DEFAULT_APPEARANCE.CORNER_RADIUS);
+      setBorderEnabled(
+        preset.borderEnabled ?? DEFAULT_APPEARANCE.BORDER_ENABLED
+      );
+      setBorderColor(preset.borderColor ?? DEFAULT_APPEARANCE.BORDER_COLOR);
+      setBorderWidth(preset.borderWidth ?? DEFAULT_APPEARANCE.BORDER_WIDTH);
       setColorPalette(preset.colorPalette || []);
     } else {
       setName("");
       setBackgroundColor(DEFAULT_BACKGROUND);
       setIconColor(DEFAULT_ICON_COLOR);
+      setCornerRadius(DEFAULT_APPEARANCE.CORNER_RADIUS);
+      setBorderEnabled(DEFAULT_APPEARANCE.BORDER_ENABLED);
+      setBorderColor(DEFAULT_APPEARANCE.BORDER_COLOR);
+      setBorderWidth(DEFAULT_APPEARANCE.BORDER_WIDTH);
       setColorPalette([]);
     }
   }, [preset, open]);
@@ -90,6 +115,10 @@ export function StylePresetEditor({
       name: name.trim(),
       backgroundColor,
       iconColor,
+      cornerRadius,
+      borderEnabled,
+      borderColor,
+      borderWidth,
       colorPalette: colorPalette.length > 0 ? colorPalette : undefined,
     });
 
@@ -165,6 +194,10 @@ export function StylePresetEditor({
               <StylePreview
                 backgroundColor={backgroundColor}
                 iconColor={iconColor}
+                cornerRadius={cornerRadius}
+                borderEnabled={borderEnabled}
+                borderColor={borderColor}
+                borderWidth={borderWidth}
               />
             </div>
 
@@ -186,6 +219,51 @@ export function StylePresetEditor({
               onChange={setIconColor}
               colorType="icon"
             />
+
+            <Separator />
+
+            <div className="space-y-4">
+              <Label>Appearance</Label>
+              <EffectSlider
+                id="style-corner-radius"
+                label="Corner Radius"
+                value={cornerRadius}
+                onChange={setCornerRadius}
+                min={0}
+                max={100}
+                step={1}
+                unit="%"
+              />
+              <div className="flex items-center justify-between">
+                <Label htmlFor="style-border-enabled">Border</Label>
+                <Switch
+                  id="style-border-enabled"
+                  checked={borderEnabled}
+                  onCheckedChange={setBorderEnabled}
+                />
+              </div>
+              {borderEnabled ? (
+                <>
+                  <EffectSlider
+                    id="style-border-width"
+                    label="Border Width"
+                    value={borderWidth}
+                    onChange={setBorderWidth}
+                    min={0}
+                    max={40}
+                    step={1}
+                    unit="px"
+                  />
+                  <ColorPicker
+                    id="style-border-color"
+                    label="Border Color"
+                    value={borderColor}
+                    onChange={setBorderColor}
+                    colorType="icon"
+                  />
+                </>
+              ) : null}
+            </div>
 
             <Separator />
 
@@ -264,9 +342,20 @@ export function StylePresetEditor({
 interface StylePreviewProps {
   backgroundColor: BackgroundValue;
   iconColor: string;
+  cornerRadius: number;
+  borderEnabled: boolean;
+  borderColor: string;
+  borderWidth: number;
 }
 
-function StylePreview({ backgroundColor, iconColor }: StylePreviewProps) {
+function StylePreview({
+  backgroundColor,
+  iconColor,
+  cornerRadius,
+  borderEnabled,
+  borderColor,
+  borderWidth,
+}: StylePreviewProps) {
   const getBackgroundStyle = (): React.CSSProperties => {
     if (typeof backgroundColor === "string") {
       return { backgroundColor };
@@ -293,7 +382,12 @@ function StylePreview({ backgroundColor, iconColor }: StylePreviewProps) {
   return (
     <div
       className="h-24 rounded-lg border flex items-center justify-center"
-      style={getBackgroundStyle()}
+      style={{
+        ...getBackgroundStyle(),
+        borderRadius: `${Math.max(0, Math.min(100, cornerRadius))}%`,
+        borderColor: borderEnabled ? borderColor : undefined,
+        borderWidth: borderEnabled ? Math.max(1, borderWidth / 4) : undefined,
+      }}
     >
       <svg
         viewBox="0 0 24 24"

--- a/src/components/StylePresetSelector.tsx
+++ b/src/components/StylePresetSelector.tsx
@@ -3,7 +3,7 @@
  */
 
 import * as React from "react";
-import { Palette, Plus, Trash2, Edit2 } from "lucide-react";
+import { Plus, Trash2, Edit2 } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import {
@@ -71,8 +71,7 @@ export function StylePresetSelector({
   return (
     <div className={className}>
       {showLabel && (
-        <div className="mb-2 flex items-center gap-2">
-          <Palette className="h-4 w-4 text-muted-foreground" />
+        <div className="mb-2">
           <Label className="text-sm font-medium">Style Preset</Label>
         </div>
       )}

--- a/src/components/SvgPreview.tsx
+++ b/src/components/SvgPreview.tsx
@@ -78,6 +78,10 @@ export function SvgPreview({ svgFiles, iconId, state }: SvgPreviewProps) {
             padding,
             outputSize: previewSize, // Use 64px output for preview
             zendeskLocationMode: isZendeskLocationSvg,
+            cornerRadius: state.cornerRadius,
+            borderEnabled: state.borderEnabled,
+            borderColor: state.borderColor,
+            borderWidth: state.borderWidth,
           });
 
           const blob = new Blob([svgString], { type: "image/svg+xml" });

--- a/src/components/__tests__/ColorPicker.test.tsx
+++ b/src/components/__tests__/ColorPicker.test.tsx
@@ -1,16 +1,22 @@
+import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ColorPicker } from "../ColorPicker";
 
-// Mock the color-history module
-vi.mock("../../utils/color-history", () => ({
-  getRecentColors: vi.fn().mockReturnValue(["#ff0000", "#00ff00", "#0000ff"]),
-  addColorToHistory: vi.fn(),
+const { getRecentColorsMock, addColorToHistoryMock } = vi.hoisted(() => ({
+  getRecentColorsMock: vi
+    .fn()
+    .mockReturnValue(["#ff0000", "#00ff00", "#0000ff"]),
+  addColorToHistoryMock: vi.fn(),
 }));
 
-// Mock the debounce hook to return value immediately for testing
-vi.mock("../../hooks/use-debounced-value", () => ({
+vi.mock("@/src/utils/color-history", () => ({
+  getRecentColors: getRecentColorsMock,
+  addColorToHistory: addColorToHistoryMock,
+}));
+
+vi.mock("@/src/hooks/use-debounced-value", () => ({
   useDebouncedValue: vi.fn((value: string) => value),
 }));
 
@@ -22,37 +28,117 @@ describe("ColorPicker", () => {
     onChange: vi.fn(),
   };
 
+  const paletteColors = [
+    { id: "color-1", name: "Primary", color: "#ff0000" },
+    { id: "color-2", name: "Secondary", color: "#00ff00" },
+    { id: "color-3", name: "Tertiary", color: "#0000ff" },
+  ];
+
   beforeEach(() => {
     vi.clearAllMocks();
+    getRecentColorsMock.mockReturnValue(["#ff0000", "#00ff00", "#0000ff"]);
   });
 
-  it("renders label", () => {
+  it("renders label when provided", () => {
     render(<ColorPicker {...defaultProps} />);
     expect(screen.getByText("Test Color")).toBeInTheDocument();
   });
 
-  it("renders color input with correct value", () => {
-    render(<ColorPicker {...defaultProps} value="#ff0000" />);
-    const colorInput = screen.getByRole("textbox");
-    expect(colorInput).toHaveValue("#ff0000");
+  it("does not render label when omitted", () => {
+    render(
+      <ColorPicker id="no-label-color" value="#ffffff" onChange={vi.fn()} />
+    );
+    expect(screen.queryByText("Test Color")).not.toBeInTheDocument();
   });
 
-  it("renders native color picker", () => {
+  it("renders hex input with current value", () => {
+    render(<ColorPicker {...defaultProps} value="#ff0000" />);
+    expect(screen.getByRole("textbox")).toHaveValue("#ff0000");
+  });
+
+  it("renders native color input", () => {
     const { container } = render(<ColorPicker {...defaultProps} />);
-    const colorPicker = container.querySelector('input[type="color"]');
-    expect(colorPicker).toBeInTheDocument();
-    expect(colorPicker).toHaveValue("#ffffff");
+    const colorInput = container.querySelector('input[type="color"]');
+    expect(colorInput).toBeInTheDocument();
+    expect(colorInput).toHaveValue("#ffffff");
+  });
+
+  it("shows expand button when tray content exists", () => {
+    render(<ColorPicker {...defaultProps} colorType="background" />);
+    expect(
+      screen.getByRole("button", { name: "Show color swatches" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not show expand button when no tray content exists", () => {
+    render(<ColorPicker {...defaultProps} />);
+    expect(
+      screen.queryByRole("button", { name: "Show color swatches" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps tray collapsed by default", () => {
+    render(<ColorPicker {...defaultProps} colorType="background" />);
+    expect(screen.queryByText("Recent colors")).not.toBeInTheDocument();
+  });
+
+  it("expands tray and renders recent colors on toggle", async () => {
+    const user = userEvent.setup();
+    render(<ColorPicker {...defaultProps} colorType="background" />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Show color swatches" })
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Select color #ff0000" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Hide color swatches" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders both section labels when both preset and recent groups exist", async () => {
+    const user = userEvent.setup();
+    render(
+      <ColorPicker
+        {...defaultProps}
+        colorType="background"
+        paletteColors={paletteColors}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Show color swatches" })
+    );
+
+    expect(screen.getByText("Preset colors")).toBeInTheDocument();
+    expect(screen.getByText("Recent colors")).toBeInTheDocument();
+  });
+
+  it("hides section label when only one swatch group exists", async () => {
+    const user = userEvent.setup();
+    render(<ColorPicker {...defaultProps} colorType="background" />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Show color swatches" })
+    );
+
+    expect(screen.queryByText("Recent colors")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Select color #ff0000" })
+    ).toBeInTheDocument();
   });
 
   it("calls onChange when hex input changes", async () => {
     const onChange = vi.fn();
+    const user = userEvent.setup();
     render(<ColorPicker {...defaultProps} onChange={onChange} />);
 
     const hexInput = screen.getByRole("textbox");
-    await userEvent.clear(hexInput);
-    await userEvent.type(hexInput, "#abcdef");
+    await user.clear(hexInput);
+    await user.type(hexInput, "#abcdef");
 
-    // onChange is called for each character
     expect(onChange).toHaveBeenCalled();
   });
 
@@ -70,48 +156,78 @@ describe("ColorPicker", () => {
     expect(onChange).toHaveBeenCalledWith("#00ff00");
   });
 
-  it("renders recent colors when colorType is provided", () => {
-    render(<ColorPicker {...defaultProps} colorType="background" />);
-    expect(screen.getByText("Recent colors")).toBeInTheDocument();
-  });
-
-  it("does not render recent colors when colorType is not provided", () => {
-    render(<ColorPicker {...defaultProps} />);
-    expect(screen.queryByText("Recent colors")).not.toBeInTheDocument();
-  });
-
-  it("renders recent color buttons", () => {
+  it("keeps tray open after swatch click in uncontrolled mode", async () => {
+    const user = userEvent.setup();
     render(<ColorPicker {...defaultProps} colorType="background" />);
 
-    // Should have buttons for the mocked recent colors
-    const buttons = screen.getAllByRole("button");
-    expect(buttons.length).toBe(3); // 3 mocked recent colors
+    await user.click(
+      screen.getByRole("button", { name: "Show color swatches" })
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Select color #ff0000" })
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Hide color swatches" })
+    ).toBeInTheDocument();
   });
 
-  it("calls onChange when recent color is clicked", async () => {
-    const onChange = vi.fn();
+  it("supports controlled tray state with external expansion callback", async () => {
+    const onExpandedChange = vi.fn();
+    const user = userEvent.setup();
     render(
       <ColorPicker
         {...defaultProps}
-        onChange={onChange}
         colorType="background"
+        expanded={false}
+        onExpandedChange={onExpandedChange}
       />
     );
 
-    const recentColorButtons = screen.getAllByRole("button");
-    await userEvent.click(recentColorButtons[0]);
+    await user.click(
+      screen.getByRole("button", { name: "Show color swatches" })
+    );
 
-    expect(onChange).toHaveBeenCalledWith("#ff0000");
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+    expect(
+      screen.queryByRole("button", { name: "Select color #ff0000" })
+    ).not.toBeInTheDocument();
   });
 
-  it("shows info tooltip when isCustomSvg is true", () => {
+  it("lets parent close tray after swatch selection in controlled mode", async () => {
+    const user = userEvent.setup();
+
+    function ControlledPicker() {
+      const [expanded, setExpanded] = React.useState(true);
+      return (
+        <ColorPicker
+          {...defaultProps}
+          colorType="background"
+          expanded={expanded}
+          onExpandedChange={setExpanded}
+          onChange={() => setExpanded(false)}
+        />
+      );
+    }
+
+    render(<ControlledPicker />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Select color #ff0000" })
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Hide color swatches" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows info tooltip icon when isCustomSvg is true", () => {
     render(<ColorPicker {...defaultProps} isCustomSvg />);
-    // The Info icon should be rendered
     const infoIcon = document.querySelector(".lucide-info");
     expect(infoIcon).toBeInTheDocument();
   });
 
-  it("does not show info tooltip when isCustomSvg is false", () => {
+  it("does not show info tooltip icon when isCustomSvg is false", () => {
     render(<ColorPicker {...defaultProps} isCustomSvg={false} />);
     const infoIcon = document.querySelector(".lucide-info");
     expect(infoIcon).not.toBeInTheDocument();
@@ -124,106 +240,65 @@ describe("ColorPicker", () => {
     expect(container.firstChild).toHaveClass("my-custom-class");
   });
 
-  it("validates hex input - rejects invalid characters", async () => {
+  it("validates hex input and rejects invalid characters", async () => {
     const onChange = vi.fn();
+    const user = userEvent.setup();
     render(<ColorPicker {...defaultProps} onChange={onChange} value="" />);
 
     const hexInput = screen.getByRole("textbox");
-    await userEvent.type(hexInput, "xyz");
+    await user.type(hexInput, "xyz");
 
-    // onChange should not be called for invalid characters
     expect(onChange).not.toHaveBeenCalledWith("xyz");
   });
 
-  it("allows valid hex input", async () => {
+  it("allows valid partial hex input", async () => {
     const onChange = vi.fn();
+    const user = userEvent.setup();
     render(<ColorPicker {...defaultProps} onChange={onChange} value="" />);
 
     const hexInput = screen.getByRole("textbox");
-    await userEvent.type(hexInput, "#");
+    await user.type(hexInput, "#");
 
     expect(onChange).toHaveBeenCalledWith("#");
   });
 
-  it("has proper accessibility labels for recent colors", () => {
+  it("records valid full hex colors in history", async () => {
+    const user = userEvent.setup();
     render(<ColorPicker {...defaultProps} colorType="background" />);
 
-    const buttons = screen.getAllByRole("button");
-    buttons.forEach((button) => {
-      expect(button).toHaveAttribute("aria-label");
-    });
+    const hexInput = screen.getByRole("textbox");
+    await user.clear(hexInput);
+    await user.type(hexInput, "#abcdef");
+
+    expect(addColorToHistoryMock).toHaveBeenCalledWith("background", "#abcdef");
   });
 
-  describe("paletteColors prop", () => {
-    const paletteColors = [
-      { id: "color-1", name: "Primary", color: "#ff0000" },
-      { id: "color-2", name: "Secondary", color: "#00ff00" },
-      { id: "color-3", name: "Tertiary", color: "#0000ff" },
-    ];
+  it("does not record non-full-hex values in history", async () => {
+    const user = userEvent.setup();
+    render(<ColorPicker {...defaultProps} colorType="background" />);
 
-    it("renders preset colors section when paletteColors is provided", () => {
-      render(<ColorPicker {...defaultProps} paletteColors={paletteColors} />);
-      expect(screen.getByText("Preset colors")).toBeInTheDocument();
-    });
+    const hexInput = screen.getByRole("textbox");
+    await user.clear(hexInput);
+    await user.type(hexInput, "#abc");
 
-    it("does not render preset colors section when paletteColors is empty", () => {
-      render(<ColorPicker {...defaultProps} paletteColors={[]} />);
-      expect(screen.queryByText("Preset colors")).not.toBeInTheDocument();
-    });
+    expect(addColorToHistoryMock).not.toHaveBeenCalledWith(
+      "background",
+      "#abc"
+    );
+  });
 
-    it("does not render preset colors section when paletteColors is undefined", () => {
-      render(<ColorPicker {...defaultProps} />);
-      expect(screen.queryByText("Preset colors")).not.toBeInTheDocument();
-    });
+  it("renders restricted mode with palette swatches only", () => {
+    render(
+      <ColorPicker
+        {...defaultProps}
+        paletteColors={paletteColors}
+        restrictedMode
+      />
+    );
 
-    it("renders palette color buttons", () => {
-      render(<ColorPicker {...defaultProps} paletteColors={paletteColors} />);
-
-      // Should have buttons for the palette colors
-      const buttons = screen.getAllByRole("button");
-      expect(buttons.length).toBe(3); // 3 palette colors
-    });
-
-    it("calls onChange when palette color is clicked", async () => {
-      const onChange = vi.fn();
-      render(
-        <ColorPicker
-          {...defaultProps}
-          onChange={onChange}
-          paletteColors={paletteColors}
-        />
-      );
-
-      const paletteButtons = screen.getAllByRole("button");
-      await userEvent.click(paletteButtons[0]);
-
-      expect(onChange).toHaveBeenCalledWith("#ff0000");
-    });
-
-    it("has proper accessibility labels for palette colors", () => {
-      render(<ColorPicker {...defaultProps} paletteColors={paletteColors} />);
-
-      const buttons = screen.getAllByRole("button");
-      buttons.forEach((button) => {
-        expect(button).toHaveAttribute("aria-label");
-      });
-    });
-
-    it("renders both palette colors and recent colors when both are provided", () => {
-      render(
-        <ColorPicker
-          {...defaultProps}
-          paletteColors={paletteColors}
-          colorType="background"
-        />
-      );
-
-      expect(screen.getByText("Preset colors")).toBeInTheDocument();
-      expect(screen.getByText("Recent colors")).toBeInTheDocument();
-
-      // Should have 3 palette + 3 recent = 6 color buttons
-      const buttons = screen.getAllByRole("button");
-      expect(buttons.length).toBe(6);
-    });
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Select Primary (#ff0000)" })
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/CustomizationControlsPane.test.tsx
+++ b/src/components/__tests__/CustomizationControlsPane.test.tsx
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { CustomizationControlsPane } from "../../../components/CustomizationControlsPane";
+import { usePresets } from "../../hooks/use-presets";
+import { useRestriction } from "../../contexts/RestrictionContext";
+import type { ExportPreset } from "../../types/preset";
+
+vi.mock("../../hooks/use-presets", () => ({
+  usePresets: vi.fn(),
+}));
+
+vi.mock("../../contexts/RestrictionContext", () => ({
+  useRestriction: vi.fn(),
+}));
+
+vi.mock("../StylePresetSelector", () => ({
+  StylePresetSelector: () => null,
+}));
+
+vi.mock("../StylePresetEditor", () => ({
+  StylePresetEditor: () => null,
+}));
+
+vi.mock("../PresetSettingsModal", () => ({
+  PresetSettingsModal: () => null,
+}));
+
+const pngPreset: ExportPreset = {
+  id: "png-only",
+  name: "PNG Only",
+  description: "PNG files only",
+  variants: [{ filename: "logo.png", width: 512, height: 512, format: "png" }],
+  isBuiltIn: false,
+};
+
+const svgPreset: ExportPreset = {
+  id: "svg-mixed",
+  name: "SVG Mixed",
+  description: "PNG and SVG",
+  variants: [
+    { filename: "logo.png", width: 512, height: 512, format: "png" },
+    {
+      filename: "icon-nav-bar.svg",
+      width: 16,
+      height: 16,
+      format: "svg",
+      location: "nav_bar",
+    },
+  ],
+  isBuiltIn: false,
+};
+
+function mockPresets(selectedExportPresetId: string) {
+  vi.mocked(usePresets).mockReturnValue({
+    exportPresets: [pngPreset, svgPreset],
+    selectedExportPresetId,
+    selectedExportPreset: undefined,
+    selectExportPreset: vi.fn(),
+    createExportPreset: vi.fn(),
+    updateExportPreset: vi.fn(),
+    deleteExportPreset: vi.fn(),
+    hasCustomExportPresets: false,
+    stylePresets: [],
+    selectedStylePresetId: null,
+    selectedStylePreset: undefined,
+    selectStylePreset: vi.fn(),
+    createStylePreset: vi.fn(),
+    updateStylePreset: vi.fn(),
+    deleteStylePreset: vi.fn(),
+    hasCustomStylePresets: false,
+    exportAllPresets: vi.fn(),
+    importPresets: vi.fn(),
+    clearCustomPresets: vi.fn(),
+    isLoading: false,
+  });
+}
+
+describe("CustomizationControlsPane", () => {
+  beforeEach(() => {
+    vi.mocked(useRestriction).mockReturnValue({
+      isRestricted: false,
+      allowedStyles: [],
+      allowedExportPresets: null,
+      allowedIconPacks: [
+        "all",
+        "garden",
+        "feather",
+        "remixicon",
+        "emoji",
+        "custom-svg",
+        "custom-image",
+        "canvas",
+      ],
+      defaultIconPack: null,
+      isIconPackAllowed: () => true,
+      isExportPresetAllowed: () => true,
+      getShareableUrl: () => null,
+      config: null,
+      isLoading: false,
+    });
+  });
+
+  it("hides SVG size control when selected preset has no SVG variant", () => {
+    mockPresets("png-only");
+
+    render(
+      <CustomizationControlsPane
+        iconSize={120}
+        svgIconSize={120}
+        onIconSizeChange={vi.fn()}
+        onSvgIconSizeChange={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /icon size/i }));
+
+    expect(screen.getByText("Size")).toBeInTheDocument();
+    expect(screen.queryByText("PNG Size")).not.toBeInTheDocument();
+    expect(screen.queryByText("SVG Size")).not.toBeInTheDocument();
+  });
+
+  it("shows SVG size control when selected preset includes SVG variant", () => {
+    mockPresets("svg-mixed");
+
+    render(
+      <CustomizationControlsPane
+        iconSize={120}
+        svgIconSize={120}
+        onIconSizeChange={vi.fn()}
+        onSvgIconSizeChange={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /icon size/i }));
+
+    expect(screen.getByText("PNG Size")).toBeInTheDocument();
+    expect(screen.getByText("SVG Size")).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/LinearGradientEditor.test.tsx
+++ b/src/components/__tests__/LinearGradientEditor.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LinearGradientEditor } from "../LinearGradientEditor";
+import type { LinearGradient } from "@/src/utils/gradients";
+
+const { getRecentColorsMock, addColorToHistoryMock } = vi.hoisted(() => ({
+  getRecentColorsMock: vi
+    .fn()
+    .mockReturnValue(["#ff0000", "#00ff00", "#0000ff"]),
+  addColorToHistoryMock: vi.fn(),
+}));
+
+vi.mock("@/src/utils/color-history", () => ({
+  getRecentColors: getRecentColorsMock,
+  addColorToHistory: addColorToHistoryMock,
+}));
+
+vi.mock("@/src/hooks/use-debounced-value", () => ({
+  useDebouncedValue: vi.fn((value: string) => value),
+}));
+
+describe("LinearGradientEditor", () => {
+  const baseGradient: LinearGradient = {
+    type: "linear",
+    angle: 90,
+    stops: [
+      { color: "#112233", position: 0 },
+      { color: "#445566", position: 100 },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRecentColorsMock.mockReturnValue(["#ff0000", "#00ff00", "#0000ff"]);
+  });
+
+  it("renders stop labels", () => {
+    render(
+      <LinearGradientEditor
+        gradient={baseGradient}
+        onGradientChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("From")).toBeInTheDocument();
+    expect(screen.getByText("To")).toBeInTheDocument();
+  });
+
+  it("keeps only one swatch tray open at a time", async () => {
+    const user = userEvent.setup();
+    render(
+      <LinearGradientEditor
+        gradient={baseGradient}
+        onGradientChange={vi.fn()}
+      />
+    );
+
+    const showButtons = screen.getAllByRole("button", {
+      name: "Show color swatches",
+    });
+    expect(showButtons).toHaveLength(2);
+
+    await user.click(showButtons[0]);
+    expect(
+      screen.getAllByRole("button", { name: "Select color #ff0000" })
+    ).toHaveLength(1);
+
+    await user.click(
+      screen.getByRole("button", { name: "Show color swatches" })
+    );
+    expect(
+      screen.getAllByRole("button", { name: "Select color #ff0000" })
+    ).toHaveLength(1);
+  });
+
+  it("propagates stop color changes", async () => {
+    const user = userEvent.setup();
+    const onGradientChange = vi.fn();
+    render(
+      <LinearGradientEditor
+        gradient={baseGradient}
+        onGradientChange={onGradientChange}
+      />
+    );
+
+    const textboxes = screen.getAllByRole("textbox");
+    await user.clear(textboxes[0]);
+    await user.type(textboxes[0], "#abcdef");
+
+    expect(onGradientChange).toHaveBeenCalled();
+    const lastCallArg = onGradientChange.mock.calls.at(
+      -1
+    )?.[0] as LinearGradient;
+    expect(lastCallArg.stops[0].color).toBe("#abcdef");
+  });
+});

--- a/src/components/__tests__/PresetPreview.test.tsx
+++ b/src/components/__tests__/PresetPreview.test.tsx
@@ -60,6 +60,10 @@ describe("PresetPreview", () => {
     selectedPack: "all",
     iconSize: 123,
     svgIconSize: 123,
+    cornerRadius: 0,
+    borderEnabled: false,
+    borderColor: "#ffffff",
+    borderWidth: 6,
   };
 
   beforeEach(async () => {

--- a/src/components/__tests__/PreviewPane.test.tsx
+++ b/src/components/__tests__/PreviewPane.test.tsx
@@ -92,6 +92,10 @@ describe("PreviewPane", () => {
     selectedPack: "all",
     iconSize: 123,
     svgIconSize: 123,
+    cornerRadius: 0,
+    borderEnabled: false,
+    borderColor: "#ffffff",
+    borderWidth: 6,
     ...overrides,
   });
 

--- a/src/components/__tests__/RadialGradientEditor.test.tsx
+++ b/src/components/__tests__/RadialGradientEditor.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RadialGradientEditor } from "../RadialGradientEditor";
+import type { RadialGradient } from "@/src/utils/gradients";
+
+const { getRecentColorsMock, addColorToHistoryMock } = vi.hoisted(() => ({
+  getRecentColorsMock: vi
+    .fn()
+    .mockReturnValue(["#ff0000", "#00ff00", "#0000ff"]),
+  addColorToHistoryMock: vi.fn(),
+}));
+
+vi.mock("@/src/utils/color-history", () => ({
+  getRecentColors: getRecentColorsMock,
+  addColorToHistory: addColorToHistoryMock,
+}));
+
+vi.mock("@/src/hooks/use-debounced-value", () => ({
+  useDebouncedValue: vi.fn((value: string) => value),
+}));
+
+describe("RadialGradientEditor", () => {
+  const baseGradient: RadialGradient = {
+    type: "radial",
+    centerX: 50,
+    centerY: 50,
+    radius: 50,
+    stops: [
+      { color: "#112233", position: 0 },
+      { color: "#445566", position: 100 },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRecentColorsMock.mockReturnValue(["#ff0000", "#00ff00", "#0000ff"]);
+  });
+
+  it("renders stop labels", () => {
+    render(
+      <RadialGradientEditor
+        gradient={baseGradient}
+        onGradientChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Center")).toBeInTheDocument();
+    expect(screen.getByText("Edge")).toBeInTheDocument();
+  });
+
+  it("keeps only one swatch tray open at a time", async () => {
+    const user = userEvent.setup();
+    render(
+      <RadialGradientEditor
+        gradient={baseGradient}
+        onGradientChange={vi.fn()}
+      />
+    );
+
+    const showButtons = screen.getAllByRole("button", {
+      name: "Show color swatches",
+    });
+    expect(showButtons).toHaveLength(2);
+
+    await user.click(showButtons[0]);
+    expect(
+      screen.getAllByRole("button", { name: "Select color #ff0000" })
+    ).toHaveLength(1);
+
+    await user.click(
+      screen.getByRole("button", { name: "Show color swatches" })
+    );
+    expect(
+      screen.getAllByRole("button", { name: "Select color #ff0000" })
+    ).toHaveLength(1);
+  });
+
+  it("propagates stop color changes", async () => {
+    const user = userEvent.setup();
+    const onGradientChange = vi.fn();
+    render(
+      <RadialGradientEditor
+        gradient={baseGradient}
+        onGradientChange={onGradientChange}
+      />
+    );
+
+    const textboxes = screen.getAllByRole("textbox");
+    await user.clear(textboxes[0]);
+    await user.type(textboxes[0], "#abcdef");
+
+    expect(onGradientChange).toHaveBeenCalled();
+    const lastCallArg = onGradientChange.mock.calls.at(
+      -1
+    )?.[0] as RadialGradient;
+    expect(lastCallArg.stops[0].color).toBe("#abcdef");
+  });
+});

--- a/src/components/share/StyleEditorCard.tsx
+++ b/src/components/share/StyleEditorCard.tsx
@@ -91,8 +91,8 @@ export function StyleEditorCard({
                   id="icon-color"
                   value={editingStyle.iconColor}
                   onChange={handleIconColorChange}
-                  colorInputClassName="h-10 w-20 cursor-pointer rounded-md border"
-                  textInputClassName="flex-1 font-mono"
+                  colorInputClassName="h-9 w-9 cursor-pointer rounded-md border border-input bg-background p-0"
+                  textInputClassName="h-9 flex-1 px-2.5 font-mono text-xs sm:text-sm"
                 />
               </div>
             </div>
@@ -130,8 +130,8 @@ export function StyleEditorCard({
                         onChange={(value) =>
                           onUpdatePaletteColor(colorIndex, { color: value })
                         }
-                        colorInputClassName="h-8 w-12 cursor-pointer rounded border flex-shrink-0"
-                        textInputClassName="w-24 font-mono text-xs"
+                        colorInputClassName="h-9 w-9 cursor-pointer rounded-md border border-input bg-background p-0 flex-shrink-0"
+                        textInputClassName="h-9 w-24 px-2.5 font-mono text-xs"
                       />
                       <Input
                         value={color.name}

--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -67,6 +67,16 @@ export const DEFAULT_COLORS = {
 } as const;
 
 /**
+ * Default appearance values
+ */
+export const DEFAULT_APPEARANCE = {
+  CORNER_RADIUS: 0,
+  BORDER_ENABLED: false,
+  BORDER_COLOR: "#ffffff",
+  BORDER_WIDTH: 6,
+} as const;
+
+/**
  * Layout breakpoints and sizing
  */
 export const LAYOUT = {

--- a/src/hooks/__tests__/use-icon-generator.test.ts
+++ b/src/hooks/__tests__/use-icon-generator.test.ts
@@ -44,6 +44,10 @@ describe("useIconGenerator", () => {
       expect(result.current.state.selectedPack).toBe("all");
       expect(result.current.state.iconSize).toBe(123);
       expect(result.current.state.svgIconSize).toBe(123);
+      expect(result.current.state.cornerRadius).toBe(0);
+      expect(result.current.state.borderEnabled).toBe(false);
+      expect(result.current.state.borderColor).toBe("#ffffff");
+      expect(result.current.state.borderWidth).toBe(6);
     });
 
     it("provides action functions", () => {
@@ -59,6 +63,10 @@ describe("useIconGenerator", () => {
       expect(typeof result.current.actions.setSelectedPack).toBe("function");
       expect(typeof result.current.actions.setIconSize).toBe("function");
       expect(typeof result.current.actions.setSvgIconSize).toBe("function");
+      expect(typeof result.current.actions.setCornerRadius).toBe("function");
+      expect(typeof result.current.actions.setBorderEnabled).toBe("function");
+      expect(typeof result.current.actions.setBorderColor).toBe("function");
+      expect(typeof result.current.actions.setBorderWidth).toBe("function");
     });
   });
 
@@ -164,6 +172,22 @@ describe("useIconGenerator", () => {
 
       expect(result.current.state.svgIconSize).toBe(100);
     });
+
+    it("updates border and corner controls", async () => {
+      const { result } = renderHook(() => useIconGenerator());
+
+      act(() => {
+        result.current.actions.setCornerRadius(24);
+        result.current.actions.setBorderEnabled(true);
+        result.current.actions.setBorderColor("#00ff00");
+        result.current.actions.setBorderWidth(10);
+      });
+
+      expect(result.current.state.cornerRadius).toBe(24);
+      expect(result.current.state.borderEnabled).toBe(true);
+      expect(result.current.state.borderColor).toBe("#00ff00");
+      expect(result.current.state.borderWidth).toBe(10);
+    });
   });
 
   describe("localStorage persistence", () => {
@@ -176,6 +200,10 @@ describe("useIconGenerator", () => {
         selectedPack: "feather",
         iconSize: 100,
         svgIconSize: 80,
+        cornerRadius: 12,
+        borderEnabled: true,
+        borderColor: "#ff0000",
+        borderWidth: 8,
       };
       localStorage.setItem(
         "zdk-icon-generator:generator-state",
@@ -195,6 +223,10 @@ describe("useIconGenerator", () => {
       expect(result.current.state.selectedPack).toBe("feather");
       expect(result.current.state.iconSize).toBe(100);
       expect(result.current.state.svgIconSize).toBe(80);
+      expect(result.current.state.cornerRadius).toBe(12);
+      expect(result.current.state.borderEnabled).toBe(true);
+      expect(result.current.state.borderColor).toBe("#ff0000");
+      expect(result.current.state.borderWidth).toBe(8);
     });
 
     it("does not persist searchQuery", async () => {
@@ -206,6 +238,10 @@ describe("useIconGenerator", () => {
         selectedPack: "all",
         iconSize: 123,
         svgIconSize: 123,
+        cornerRadius: 0,
+        borderEnabled: false,
+        borderColor: "#ffffff",
+        borderWidth: 6,
       };
       localStorage.setItem(
         "zdk-icon-generator:generator-state",

--- a/src/hooks/use-debounced-color-state.ts
+++ b/src/hooks/use-debounced-color-state.ts
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { useDebouncedValue } from "@/src/hooks/use-debounced-value";
+
+const HEX_INPUT_PATTERN = /^#[0-9A-Fa-f]{0,6}$/;
+
+export interface UseDebouncedColorStateOptions {
+  value: string;
+  onChange: (value: string) => void;
+  debounceDelay?: number;
+}
+
+export interface UseDebouncedColorStateResult {
+  localValue: string;
+  debouncedValue: string;
+  setColorValue: (value: string) => void;
+  setHexValue: (value: string) => void;
+  commitValue: (value: string) => void;
+}
+
+/**
+ * Shared state manager for color controls:
+ * - immediate local UI updates
+ * - debounced parent updates
+ * - sync when parent value changes externally
+ */
+export function useDebouncedColorState({
+  value,
+  onChange,
+  debounceDelay = 300,
+}: UseDebouncedColorStateOptions): UseDebouncedColorStateResult {
+  const [localValue, setLocalValue] = React.useState(value);
+  const lastPropValueRef = React.useRef(value);
+
+  const debouncedValue = useDebouncedValue(localValue, debounceDelay);
+
+  React.useEffect(() => {
+    if (debouncedValue !== lastPropValueRef.current) {
+      lastPropValueRef.current = debouncedValue;
+      onChange(debouncedValue);
+    }
+  }, [debouncedValue, onChange]);
+
+  React.useEffect(() => {
+    if (value !== lastPropValueRef.current) {
+      lastPropValueRef.current = value;
+      setLocalValue(value);
+    }
+  }, [value]);
+
+  const setColorValue = React.useCallback((nextValue: string) => {
+    setLocalValue(nextValue);
+  }, []);
+
+  const setHexValue = React.useCallback((nextValue: string) => {
+    if (nextValue === "" || HEX_INPUT_PATTERN.test(nextValue)) {
+      setLocalValue(nextValue);
+    }
+  }, []);
+
+  const commitValue = React.useCallback(
+    (nextValue: string) => {
+      lastPropValueRef.current = nextValue;
+      setLocalValue(nextValue);
+      onChange(nextValue);
+    },
+    [onChange]
+  );
+
+  return {
+    localValue,
+    debouncedValue,
+    setColorValue,
+    setHexValue,
+    commitValue,
+  };
+}

--- a/src/hooks/use-icon-generator.ts
+++ b/src/hooks/use-icon-generator.ts
@@ -4,7 +4,11 @@
 
 import * as React from "react";
 import type { AppLocation } from "@/src/types/app-location";
-import { ICON_PACKS, type IconPack } from "@/src/constants/app";
+import {
+  DEFAULT_APPEARANCE,
+  ICON_PACKS,
+  type IconPack,
+} from "@/src/constants/app";
 import { loadIconCatalog } from "@/src/utils/icon-catalog";
 import { getUserEmojis } from "@/src/utils/emoji-catalog";
 import {
@@ -24,6 +28,14 @@ export interface IconGeneratorState {
   iconSize: number;
   /** Icon size for SVG exports (top_bar, ticket_editor, nav_bar) */
   svgIconSize: number;
+  /** Corner radius percentage (0 = square, 100 = fully round) */
+  cornerRadius: number;
+  /** Whether border is enabled */
+  borderEnabled: boolean;
+  /** Border color */
+  borderColor: string;
+  /** Border width in normalized artboard units */
+  borderWidth: number;
 }
 
 export interface IconGeneratorActions {
@@ -35,6 +47,10 @@ export interface IconGeneratorActions {
   setSelectedPack: (pack: IconPack) => void;
   setIconSize: (size: number) => void;
   setSvgIconSize: (size: number) => void;
+  setCornerRadius: (radius: number) => void;
+  setBorderEnabled: (enabled: boolean) => void;
+  setBorderColor: (color: string) => void;
+  setBorderWidth: (width: number) => void;
 }
 
 const DEFAULT_STATE: IconGeneratorState = {
@@ -46,6 +62,10 @@ const DEFAULT_STATE: IconGeneratorState = {
   selectedPack: ICON_PACKS.ALL,
   iconSize: 123,
   svgIconSize: 123,
+  cornerRadius: DEFAULT_APPEARANCE.CORNER_RADIUS,
+  borderEnabled: DEFAULT_APPEARANCE.BORDER_ENABLED,
+  borderColor: DEFAULT_APPEARANCE.BORDER_COLOR,
+  borderWidth: DEFAULT_APPEARANCE.BORDER_WIDTH,
 };
 
 export function useIconGenerator() {
@@ -95,6 +115,24 @@ export function useIconGenerator() {
             persistedState.svgIconSize > 0
               ? persistedState.svgIconSize
               : DEFAULT_STATE.svgIconSize,
+          cornerRadius:
+            typeof persistedState.cornerRadius === "number" &&
+            persistedState.cornerRadius >= 0
+              ? persistedState.cornerRadius
+              : DEFAULT_STATE.cornerRadius,
+          borderEnabled:
+            typeof persistedState.borderEnabled === "boolean"
+              ? persistedState.borderEnabled
+              : DEFAULT_STATE.borderEnabled,
+          borderColor:
+            typeof persistedState.borderColor === "string"
+              ? persistedState.borderColor
+              : DEFAULT_STATE.borderColor,
+          borderWidth:
+            typeof persistedState.borderWidth === "number" &&
+            persistedState.borderWidth >= 0
+              ? persistedState.borderWidth
+              : DEFAULT_STATE.borderWidth,
         };
         hasPersistedIcon = !!restoredState.selectedIconId;
         setState(restoredState);
@@ -140,6 +178,10 @@ export function useIconGenerator() {
       selectedPack: state.selectedPack,
       iconSize: state.iconSize,
       svgIconSize: state.svgIconSize,
+      cornerRadius: state.cornerRadius,
+      borderEnabled: state.borderEnabled,
+      borderColor: state.borderColor,
+      borderWidth: state.borderWidth,
     });
   }, [
     hasInitialized,
@@ -151,6 +193,10 @@ export function useIconGenerator() {
     state.selectedPack,
     state.iconSize,
     state.svgIconSize,
+    state.cornerRadius,
+    state.borderEnabled,
+    state.borderColor,
+    state.borderWidth,
   ]);
 
   const actions: IconGeneratorActions = React.useMemo(
@@ -170,6 +216,14 @@ export function useIconGenerator() {
       setIconSize: (size) => setState((prev) => ({ ...prev, iconSize: size })),
       setSvgIconSize: (size) =>
         setState((prev) => ({ ...prev, svgIconSize: size })),
+      setCornerRadius: (radius) =>
+        setState((prev) => ({ ...prev, cornerRadius: radius })),
+      setBorderEnabled: (enabled) =>
+        setState((prev) => ({ ...prev, borderEnabled: enabled })),
+      setBorderColor: (color) =>
+        setState((prev) => ({ ...prev, borderColor: color })),
+      setBorderWidth: (width) =>
+        setState((prev) => ({ ...prev, borderWidth: width })),
     }),
     []
   );

--- a/src/hooks/use-share-config.ts
+++ b/src/hooks/use-share-config.ts
@@ -6,6 +6,7 @@
 
 import * as React from "react";
 import type { RestrictionConfig } from "@/src/types/restriction";
+import { DEFAULT_APPEARANCE } from "@/src/constants/app";
 import {
   createDefaultRestrictionConfig,
   isRestrictionConfig,
@@ -57,6 +58,10 @@ function generateShareUrl(config: RestrictionConfig, mode: ShareMode): string {
         name: style.name,
         backgroundColor: style.backgroundColor,
         iconColor: style.iconColor,
+        cornerRadius: DEFAULT_APPEARANCE.CORNER_RADIUS,
+        borderEnabled: DEFAULT_APPEARANCE.BORDER_ENABLED,
+        borderColor: DEFAULT_APPEARANCE.BORDER_COLOR,
+        borderWidth: DEFAULT_APPEARANCE.BORDER_WIDTH,
         isBuiltIn: false,
         colorPalette: style.colorPalette?.map((c, i) => ({
           id: `color-${i}`,
@@ -78,7 +83,7 @@ function generateShareUrl(config: RestrictionConfig, mode: ShareMode): string {
         }));
 
       const presetData = {
-        version: 2,
+        version: 3,
         exportPresets,
         stylePresets,
         exportedAt: new Date().toISOString(),

--- a/src/types/__tests__/preset.test.ts
+++ b/src/types/__tests__/preset.test.ts
@@ -73,6 +73,10 @@ describe("preset types", () => {
         name: "Test",
         backgroundColor: "#000000",
         iconColor: "#ffffff",
+        cornerRadius: 0,
+        borderEnabled: false,
+        borderColor: "#ffffff",
+        borderWidth: 6,
         isBuiltIn: false,
       };
       expect(isStylePreset(preset)).toBe(true);
@@ -84,6 +88,10 @@ describe("preset types", () => {
         name: "Test",
         backgroundColor: "#000000",
         iconColor: "#ffffff",
+        cornerRadius: 12,
+        borderEnabled: true,
+        borderColor: "#ff0000",
+        borderWidth: 8,
         isBuiltIn: false,
         colorPalette: [
           { id: "color-1", name: "Primary", color: "#ffffff" },
@@ -99,6 +107,10 @@ describe("preset types", () => {
         name: "Test",
         backgroundColor: "#000000",
         iconColor: "#ffffff",
+        cornerRadius: 0,
+        borderEnabled: false,
+        borderColor: "#ffffff",
+        borderWidth: 6,
         isBuiltIn: false,
         colorPalette: [],
       };

--- a/src/types/export.ts
+++ b/src/types/export.ts
@@ -126,6 +126,10 @@ export interface ExportMetadata {
     backgroundColor: BackgroundValue;
     iconColor: string;
     iconSize: number;
+    cornerRadius?: number;
+    borderEnabled?: boolean;
+    borderColor?: string;
+    borderWidth?: number;
   };
   locations: AppLocation[];
   variants: string[];

--- a/src/types/preset.ts
+++ b/src/types/preset.ts
@@ -73,6 +73,14 @@ export interface StylePreset {
   backgroundColor: BackgroundValue;
   /** Icon/foreground color */
   iconColor: string;
+  /** Corner radius percentage (0 = square, 100 = fully round) */
+  cornerRadius: number;
+  /** Whether border is enabled */
+  borderEnabled: boolean;
+  /** Border color */
+  borderColor: string;
+  /** Border width in normalized artboard units */
+  borderWidth: number;
   /** Whether this is a built-in preset (cannot be deleted) */
   isBuiltIn: boolean;
   /** Optional color palette for easy brand color access */
@@ -162,6 +170,33 @@ export function isStylePreset(value: unknown): value is StylePreset {
 
   // Validate colorPalette if present
   const preset = value as StylePreset;
+
+  // Validate appearance fields if present (older preset payloads may omit them)
+  if (
+    preset.cornerRadius !== undefined &&
+    (typeof preset.cornerRadius !== "number" || preset.cornerRadius < 0)
+  ) {
+    return false;
+  }
+  if (
+    preset.borderEnabled !== undefined &&
+    typeof preset.borderEnabled !== "boolean"
+  ) {
+    return false;
+  }
+  if (
+    preset.borderColor !== undefined &&
+    typeof preset.borderColor !== "string"
+  ) {
+    return false;
+  }
+  if (
+    preset.borderWidth !== undefined &&
+    (typeof preset.borderWidth !== "number" || preset.borderWidth < 0)
+  ) {
+    return false;
+  }
+
   if (preset.colorPalette !== undefined) {
     if (!Array.isArray(preset.colorPalette)) {
       return false;

--- a/src/utils/__tests__/export-controller.test.ts
+++ b/src/utils/__tests__/export-controller.test.ts
@@ -15,6 +15,10 @@ describe("export-controller", () => {
     selectedPack: "all",
     iconSize: 123,
     svgIconSize: 123,
+    cornerRadius: 0,
+    borderEnabled: false,
+    borderColor: "#ffffff",
+    borderWidth: 6,
     ...overrides,
   });
 

--- a/src/utils/__tests__/local-storage.test.ts
+++ b/src/utils/__tests__/local-storage.test.ts
@@ -171,6 +171,10 @@ describe("local-storage", () => {
       selectedPack: "zendesk",
       iconSize: 100,
       svgIconSize: 80,
+      cornerRadius: 12,
+      borderEnabled: true,
+      borderColor: "#00ff00",
+      borderWidth: 8,
     };
 
     describe("saveGeneratorState", () => {

--- a/src/utils/__tests__/preset-storage.test.ts
+++ b/src/utils/__tests__/preset-storage.test.ts
@@ -122,6 +122,10 @@ describe("preset-storage", () => {
         name: "My Style",
         backgroundColor: "#ff0000",
         iconColor: "#ffffff",
+        cornerRadius: 0,
+        borderEnabled: false,
+        borderColor: "#ffffff",
+        borderWidth: 6,
       });
 
       expect(preset.id).toBeDefined();
@@ -137,6 +141,10 @@ describe("preset-storage", () => {
         name: "My Style With Palette",
         backgroundColor: "#ff0000",
         iconColor: "#ffffff",
+        cornerRadius: 12,
+        borderEnabled: true,
+        borderColor: "#00ff00",
+        borderWidth: 8,
         colorPalette: [
           { id: "color-1", name: "Primary", color: "#ffffff" },
           { id: "color-2", name: "Secondary", color: "#000000" },
@@ -157,6 +165,10 @@ describe("preset-storage", () => {
         name: "My Style",
         backgroundColor: "#ff0000",
         iconColor: "#ffffff",
+        cornerRadius: 0,
+        borderEnabled: false,
+        borderColor: "#ffffff",
+        borderWidth: 6,
       });
 
       const updated = updateStylePreset(preset.id, {
@@ -173,6 +185,10 @@ describe("preset-storage", () => {
         name: "My Style",
         backgroundColor: "#ff0000",
         iconColor: "#ffffff",
+        cornerRadius: 0,
+        borderEnabled: false,
+        borderColor: "#ffffff",
+        borderWidth: 6,
       });
 
       const deleted = deleteStylePreset(preset.id);
@@ -210,7 +226,7 @@ describe("preset-storage", () => {
   });
 
   describe("Import/Export", () => {
-    it("should export user presets as JSON with version 2", () => {
+    it("should export user presets as JSON with version 3", () => {
       addExportPreset({
         name: "Export Test",
         description: "Test",
@@ -221,13 +237,17 @@ describe("preset-storage", () => {
         name: "Style Test",
         backgroundColor: "#000000",
         iconColor: "#ffffff",
+        cornerRadius: 0,
+        borderEnabled: false,
+        borderColor: "#ffffff",
+        borderWidth: 6,
         colorPalette: [{ id: "color-1", name: "Primary", color: "#ffffff" }],
       });
 
       const json = exportUserPresets();
       const data = JSON.parse(json);
 
-      expect(data.version).toBe(2);
+      expect(data.version).toBe(3);
       expect(data.exportPresets).toHaveLength(1);
       expect(data.stylePresets).toHaveLength(1);
       expect(data.stylePresets[0].colorPalette).toHaveLength(1);
@@ -270,7 +290,7 @@ describe("preset-storage", () => {
 
     it("should import presets with colorPalette", () => {
       const importData = JSON.stringify({
-        version: 2,
+        version: 3,
         exportPresets: [],
         stylePresets: [
           {
@@ -325,6 +345,10 @@ describe("preset-storage", () => {
         name: "Test",
         backgroundColor: "#000",
         iconColor: "#fff",
+        cornerRadius: 0,
+        borderEnabled: false,
+        borderColor: "#ffffff",
+        borderWidth: 6,
       });
       setSelectedExportPresetId("test-id");
       setSelectedStylePresetId("test-id");

--- a/src/utils/__tests__/renderer-server.test.ts
+++ b/src/utils/__tests__/renderer-server.test.ts
@@ -46,4 +46,25 @@ describe("renderer-server", () => {
     expect(output).toContain("currentColor");
     expect(output).not.toContain('fill="#ff0000"');
   });
+
+  it("renders rounded background and border", () => {
+    const icon = createIcon(
+      '<svg viewBox="0 0 24 24"><path fill="currentColor" d="M0 0"/></svg>'
+    );
+
+    const output = renderSvgServer({
+      icon,
+      backgroundColor: "#000000",
+      iconColor: "#ffffff",
+      size: 320,
+      cornerRadius: 15,
+      borderEnabled: true,
+      borderColor: "#00ff00",
+      borderWidth: 12,
+    });
+
+    expect(output).toContain('rx="24"');
+    expect(output).toContain('stroke="#00ff00"');
+    expect(output).toContain('stroke-width="12"');
+  });
 });

--- a/src/utils/__tests__/renderer.test.ts
+++ b/src/utils/__tests__/renderer.test.ts
@@ -215,6 +215,53 @@ describe("renderer", () => {
       expect(result).toContain("currentColor");
     });
 
+    it("renders rounded background and inset border", () => {
+      const icon = createMockIcon(
+        '<svg viewBox="0 0 24 24"><path d="M0 0"/></svg>'
+      );
+      const options: SvgRenderOptions = {
+        icon,
+        backgroundColor: "#000000",
+        iconColor: "#ffffff",
+        size: 320,
+        cornerRadius: 20,
+        borderEnabled: true,
+        borderColor: "#ff0000",
+        borderWidth: 10,
+      };
+
+      const result = renderSvg(options);
+
+      expect(result).toContain('rx="32"');
+      expect(result).toContain('stroke="#ff0000"');
+      expect(result).toContain('stroke-width="10"');
+      expect(result).toContain('x="5"');
+      expect(result).toContain('width="310"');
+    });
+
+    it("suppresses border and rounding in zendeskLocationMode", () => {
+      const icon = createMockIcon(
+        '<svg viewBox="0 0 24 24"><path fill="currentColor" d="M0 0"/></svg>'
+      );
+      const options: SvgRenderOptions = {
+        icon,
+        backgroundColor: "#000000",
+        iconColor: "#ffffff",
+        size: 320,
+        zendeskLocationMode: true,
+        cornerRadius: 100,
+        borderEnabled: true,
+        borderColor: "#ff0000",
+        borderWidth: 8,
+      };
+
+      const result = renderSvg(options);
+
+      expect(result).toContain("currentColor");
+      expect(result).not.toContain('stroke="#ff0000"');
+      expect(result).not.toContain('rx="30"');
+    });
+
     it("preserves stroke attributes from Feather-style icons", () => {
       const icon = createMockIcon(
         '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M0 0"/></svg>'

--- a/src/utils/builtin-presets.ts
+++ b/src/utils/builtin-presets.ts
@@ -3,11 +3,19 @@
  */
 
 import type { ExportPreset, StylePreset } from "@/src/types/preset";
+import { DEFAULT_APPEARANCE } from "@/src/constants/app";
 import {
   GRADIENT_PRESETS,
   KALE_COLORS,
   createDefaultLinearGradient,
 } from "./gradients";
+
+const DEFAULT_STYLE_APPEARANCE = {
+  cornerRadius: DEFAULT_APPEARANCE.CORNER_RADIUS,
+  borderEnabled: DEFAULT_APPEARANCE.BORDER_ENABLED,
+  borderColor: DEFAULT_APPEARANCE.BORDER_COLOR,
+  borderWidth: DEFAULT_APPEARANCE.BORDER_WIDTH,
+} as const;
 
 /**
  * Built-in export presets for various platforms
@@ -334,6 +342,7 @@ export const BUILTIN_STYLE_PRESETS: StylePreset[] = [
     name: "Zendesk Kale",
     backgroundColor: KALE_COLORS["900"],
     iconColor: "#ffffff",
+    ...DEFAULT_STYLE_APPEARANCE,
     isBuiltIn: true,
     colorPalette: [
       { id: "kale-primary", name: "Primary", color: "#ffffff" },
@@ -347,6 +356,7 @@ export const BUILTIN_STYLE_PRESETS: StylePreset[] = [
     name: "Dark Mode",
     backgroundColor: "#1e1e1e",
     iconColor: "#ffffff",
+    ...DEFAULT_STYLE_APPEARANCE,
     isBuiltIn: true,
     colorPalette: [
       { id: "dark-primary", name: "Primary", color: "#ffffff" },
@@ -360,6 +370,7 @@ export const BUILTIN_STYLE_PRESETS: StylePreset[] = [
     name: "Light Mode",
     backgroundColor: "#ffffff",
     iconColor: "#000000",
+    ...DEFAULT_STYLE_APPEARANCE,
     isBuiltIn: true,
     colorPalette: [
       { id: "light-primary", name: "Primary", color: "#000000" },
@@ -373,6 +384,7 @@ export const BUILTIN_STYLE_PRESETS: StylePreset[] = [
     name: "Ocean Gradient",
     backgroundColor: GRADIENT_PRESETS["ocean-blue"],
     iconColor: "#ffffff",
+    ...DEFAULT_STYLE_APPEARANCE,
     isBuiltIn: true,
     colorPalette: [
       { id: "ocean-primary", name: "Primary", color: "#ffffff" },
@@ -386,6 +398,7 @@ export const BUILTIN_STYLE_PRESETS: StylePreset[] = [
     name: "Sunset Gradient",
     backgroundColor: GRADIENT_PRESETS["warm-sunset"],
     iconColor: "#ffffff",
+    ...DEFAULT_STYLE_APPEARANCE,
     isBuiltIn: true,
     colorPalette: [
       { id: "sunset-primary", name: "Primary", color: "#ffffff" },
@@ -399,6 +412,7 @@ export const BUILTIN_STYLE_PRESETS: StylePreset[] = [
     name: "Forest Gradient",
     backgroundColor: GRADIENT_PRESETS["forest-green"],
     iconColor: "#ffffff",
+    ...DEFAULT_STYLE_APPEARANCE,
     isBuiltIn: true,
     colorPalette: [
       { id: "forest-primary", name: "Primary", color: "#ffffff" },
@@ -412,6 +426,7 @@ export const BUILTIN_STYLE_PRESETS: StylePreset[] = [
     name: "Purple Dream",
     backgroundColor: GRADIENT_PRESETS["purple-dream"],
     iconColor: "#ffffff",
+    ...DEFAULT_STYLE_APPEARANCE,
     isBuiltIn: true,
     colorPalette: [
       { id: "purple-primary", name: "Primary", color: "#ffffff" },
@@ -425,6 +440,7 @@ export const BUILTIN_STYLE_PRESETS: StylePreset[] = [
     name: "Rose Pink",
     backgroundColor: GRADIENT_PRESETS["rose-pink"],
     iconColor: "#ffffff",
+    ...DEFAULT_STYLE_APPEARANCE,
     isBuiltIn: true,
     colorPalette: [
       { id: "rose-primary", name: "Primary", color: "#ffffff" },
@@ -438,6 +454,7 @@ export const BUILTIN_STYLE_PRESETS: StylePreset[] = [
     name: "Kale Gradient",
     backgroundColor: createDefaultLinearGradient(),
     iconColor: "#ffffff",
+    ...DEFAULT_STYLE_APPEARANCE,
     isBuiltIn: true,
     colorPalette: [
       { id: "kaleg-primary", name: "Primary", color: "#ffffff" },
@@ -451,6 +468,7 @@ export const BUILTIN_STYLE_PRESETS: StylePreset[] = [
     name: "Midnight",
     backgroundColor: GRADIENT_PRESETS["dark-night"],
     iconColor: "#ffffff",
+    ...DEFAULT_STYLE_APPEARANCE,
     isBuiltIn: true,
     colorPalette: [
       { id: "midnight-primary", name: "Primary", color: "#ffffff" },

--- a/src/utils/export-controller.ts
+++ b/src/utils/export-controller.ts
@@ -166,6 +166,10 @@ export async function generateExportZip(
         maxFileSize: variant.maxSize ? variant.maxSize * 1024 : undefined,
         colorOverride,
         originalColor,
+        cornerRadius: state.cornerRadius,
+        borderEnabled: state.borderEnabled,
+        borderColor: state.borderColor,
+        borderWidth: state.borderWidth,
       });
       zip.file(variant.filename, blob);
       filenames.push(variant.filename);
@@ -180,6 +184,10 @@ export async function generateExportZip(
         backgroundColor: state.backgroundColor,
         iconColor: state.iconColor,
         iconSize: state.iconSize,
+        cornerRadius: state.cornerRadius,
+        borderEnabled: state.borderEnabled,
+        borderColor: state.borderColor,
+        borderWidth: state.borderWidth,
       },
       locations: selectedLocations,
       variants: filenames,
@@ -222,6 +230,10 @@ export async function generateExportZip(
       backgroundColor: state.backgroundColor,
       iconColor: state.iconColor,
       iconSize: state.iconSize,
+      cornerRadius: state.cornerRadius,
+      borderEnabled: state.borderEnabled,
+      borderColor: state.borderColor,
+      borderWidth: state.borderWidth,
     },
     locations: selectedLocations,
     variants: filenames,

--- a/src/utils/local-storage.ts
+++ b/src/utils/local-storage.ts
@@ -161,6 +161,10 @@ export interface PersistedGeneratorState {
   selectedPack: string;
   iconSize: number;
   svgIconSize?: number;
+  cornerRadius?: number;
+  borderEnabled?: boolean;
+  borderColor?: string;
+  borderWidth?: number;
 }
 
 /**

--- a/src/utils/preset-storage.ts
+++ b/src/utils/preset-storage.ts
@@ -8,6 +8,7 @@ import type {
   PresetExportData,
   PresetImportResult,
 } from "@/src/types/preset";
+import { DEFAULT_APPEARANCE } from "@/src/constants/app";
 import {
   isPresetExportData,
   isExportPreset,
@@ -33,8 +34,31 @@ const STORAGE_KEYS = {
 /**
  * Current preset export version
  * v2: Added optional colorPalette to StylePreset
+ * v3: Added cornerRadius, borderEnabled, borderColor, borderWidth
  */
-const PRESET_EXPORT_VERSION = 2;
+const PRESET_EXPORT_VERSION = 3;
+
+function normalizeStylePreset(preset: StylePreset): StylePreset {
+  return {
+    ...preset,
+    cornerRadius:
+      typeof preset.cornerRadius === "number"
+        ? preset.cornerRadius
+        : DEFAULT_APPEARANCE.CORNER_RADIUS,
+    borderEnabled:
+      typeof preset.borderEnabled === "boolean"
+        ? preset.borderEnabled
+        : DEFAULT_APPEARANCE.BORDER_ENABLED,
+    borderColor:
+      typeof preset.borderColor === "string"
+        ? preset.borderColor
+        : DEFAULT_APPEARANCE.BORDER_COLOR,
+    borderWidth:
+      typeof preset.borderWidth === "number"
+        ? preset.borderWidth
+        : DEFAULT_APPEARANCE.BORDER_WIDTH,
+  };
+}
 
 // ============================================================================
 // Export Presets
@@ -218,7 +242,7 @@ export function getCustomStylePresets(): StylePreset[] {
     const parsed = JSON.parse(stored);
     if (!Array.isArray(parsed)) return [];
 
-    return parsed.filter(isStylePreset);
+    return parsed.filter(isStylePreset).map(normalizeStylePreset);
   } catch (error) {
     console.error("Failed to load custom style presets:", error);
     return [];
@@ -271,10 +295,10 @@ export function addStylePreset(
   };
 
   const customPresets = getCustomStylePresets();
-  customPresets.push(newPreset);
+  customPresets.push(normalizeStylePreset(newPreset));
   saveCustomStylePresets(customPresets);
 
-  return newPreset;
+  return normalizeStylePreset(newPreset);
 }
 
 /**
@@ -298,7 +322,7 @@ export function updateStylePreset(
     updatedAt: new Date().toISOString(),
   };
 
-  customPresets[index] = updated;
+  customPresets[index] = normalizeStylePreset(updated);
   saveCustomStylePresets(customPresets);
 
   return updated;
@@ -485,11 +509,13 @@ export function importUserPresets(json: string): PresetImportResult {
             isBuiltIn: false,
             createdAt: new Date().toISOString(),
           };
-          existingCustom.push(newPreset);
+          existingCustom.push(normalizeStylePreset(newPreset));
           existingIds.add(newPreset.id);
           warnings.push(`Renamed duplicate style preset: ${preset.name}`);
         } else {
-          existingCustom.push({ ...preset, isBuiltIn: false });
+          existingCustom.push(
+            normalizeStylePreset({ ...preset, isBuiltIn: false })
+          );
           existingIds.add(preset.id);
         }
         stylePresetsImported++;

--- a/src/utils/renderer-server.ts
+++ b/src/utils/renderer-server.ts
@@ -18,6 +18,45 @@ export interface ServerSvgRenderOptions {
   padding?: number;
   outputSize?: number;
   zendeskLocationMode?: boolean;
+  /** Corner radius percentage (0 = square, 100 = fully round) */
+  cornerRadius?: number;
+  borderEnabled?: boolean;
+  borderColor?: string;
+  borderWidth?: number;
+}
+
+interface ServerShapeOptions {
+  cornerRadius?: number;
+  borderEnabled?: boolean;
+  borderColor?: string;
+  borderWidth?: number;
+}
+
+function normalizeShapeOptions(
+  options: ServerShapeOptions,
+  baseSize: number
+): {
+  radius: number;
+  borderEnabled: boolean;
+  borderColor: string;
+  borderWidth: number;
+} {
+  const sourceSize = 320;
+  const cornerRadius = Math.max(0, Math.min(100, options.cornerRadius ?? 0));
+  const radius = (cornerRadius / 100) * (baseSize / 2);
+
+  const borderEnabled = options.borderEnabled ?? false;
+  const rawBorderWidth = Math.max(0, options.borderWidth ?? 0);
+  const borderWidth = borderEnabled
+    ? Math.min(baseSize / 2, rawBorderWidth * (baseSize / sourceSize))
+    : 0;
+
+  return {
+    radius,
+    borderEnabled: borderEnabled && borderWidth > 0,
+    borderColor: options.borderColor ?? "#ffffff",
+    borderWidth,
+  };
 }
 
 function isRasterizedSvg(content: string): boolean {
@@ -97,6 +136,10 @@ export function renderSvgServer(options: ServerSvgRenderOptions): string {
     padding = 0,
     outputSize,
     zendeskLocationMode = false,
+    cornerRadius = 0,
+    borderEnabled = false,
+    borderColor = "#ffffff",
+    borderWidth = 0,
   } = options;
 
   const {
@@ -126,17 +169,39 @@ export function renderSvgServer(options: ServerSvgRenderOptions): string {
   const vbMinY = viewBoxParts[1] || 0;
   const vbWidth = viewBoxParts[2] || 24;
   const vbHeight = viewBoxParts[3] || 24;
+  const shape = normalizeShapeOptions(
+    { cornerRadius, borderEnabled, borderColor, borderWidth },
+    size
+  );
 
-  let backgroundElement = "";
+  const bgElements: string[] = [];
   let gradientDef = "";
 
   if (!zendeskLocationMode) {
+    const fillValue = isGradient(backgroundColor)
+      ? `url(#bg-gradient-${Math.random().toString(36).slice(2, 11)})`
+      : backgroundColor;
+
     if (isGradient(backgroundColor)) {
-      const gradientId = `bg-gradient-${Math.random().toString(36).slice(2, 11)}`;
+      const gradientId = fillValue.slice(5, -1);
       gradientDef = gradientToSvgDef(backgroundColor, gradientId, size);
-      backgroundElement = `<rect width="${size}" height="${size}" fill="url(#${gradientId})"/>`;
-    } else {
-      backgroundElement = `<rect width="${size}" height="${size}" fill="${backgroundColor}"/>`;
+    }
+
+    const radiusAttr =
+      shape.radius > 0 ? ` rx="${shape.radius}" ry="${shape.radius}"` : "";
+    bgElements.push(
+      `<rect width="${size}" height="${size}"${radiusAttr} fill="${fillValue}"/>`
+    );
+
+    if (shape.borderEnabled) {
+      const inset = shape.borderWidth / 2;
+      const borderSize = Math.max(0, size - shape.borderWidth);
+      const borderRadius = Math.max(0, shape.radius - inset);
+      const borderRadiusAttr =
+        borderRadius > 0 ? ` rx="${borderRadius}" ry="${borderRadius}"` : "";
+      bgElements.push(
+        `<rect x="${inset}" y="${inset}" width="${borderSize}" height="${borderSize}"${borderRadiusAttr} fill="none" stroke="${shape.borderColor}" stroke-width="${shape.borderWidth}"/>`
+      );
     }
   }
 
@@ -161,8 +226,8 @@ export function renderSvgServer(options: ServerSvgRenderOptions): string {
       const iconY = effectivePadding + (iconSize - scaledHeight) / 2;
       const finalSize = outputSize ?? size;
 
-      const rasterBgElements = backgroundElement
-        ? `${gradientDef ? `${gradientDef}\n` : ""}  ${backgroundElement}\n`
+      const rasterBgElements = bgElements.length
+        ? `${gradientDef ? `${gradientDef}\n` : ""}  ${bgElements.join("\n  ")}\n`
         : "";
 
       return `<svg width="${finalSize}" height="${finalSize}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -221,12 +286,12 @@ ${rasterBgElements}  <image href="${href}" width="${scaledWidth}" height="${scal
   const combinedTransform = transformParts.join(" ");
 
   const finalSize = outputSize ?? size;
-  const bgElements = backgroundElement
-    ? `${gradientDef ? `${gradientDef}\n` : ""}  ${backgroundElement}\n`
+  const backgroundElements = bgElements.length
+    ? `${gradientDef ? `${gradientDef}\n` : ""}  ${bgElements.join("\n  ")}\n`
     : "";
 
   return `<svg width="${finalSize}" height="${finalSize}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
-${bgElements}  <g transform="${combinedTransform}"${groupAttrString}>
+${backgroundElements}  <g transform="${combinedTransform}"${groupAttrString}>
     ${coloredContent}
   </g>
 </svg>`;

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -95,6 +95,14 @@ export interface SvgRenderOptions {
    * This matches Zendesk requirements: https://developer.zendesk.com/documentation/apps/app-developer-guide/styling/
    */
   zendeskLocationMode?: boolean;
+  /** Corner radius percentage (0 = square, 100 = fully round) */
+  cornerRadius?: number;
+  /** Whether border is enabled */
+  borderEnabled?: boolean;
+  /** Border color */
+  borderColor?: string;
+  /** Border width in normalized artboard units */
+  borderWidth?: number;
 }
 
 /**
@@ -105,6 +113,69 @@ export interface PngRenderOptions extends SvgRenderOptions {
   width: number;
   /** Canvas height */
   height: number;
+}
+
+interface ShapeOptions {
+  cornerRadius?: number;
+  borderEnabled?: boolean;
+  borderColor?: string;
+  borderWidth?: number;
+}
+
+interface NormalizedShape {
+  radius: number;
+  borderEnabled: boolean;
+  borderColor: string;
+  borderWidth: number;
+}
+
+function normalizeShapeOptions(
+  options: ShapeOptions,
+  baseSize: number
+): NormalizedShape {
+  const sourceSize = 320;
+  const cornerRadius = Math.max(0, Math.min(100, options.cornerRadius ?? 0));
+  const radius = (cornerRadius / 100) * (baseSize / 2);
+
+  const borderEnabled = options.borderEnabled ?? false;
+  const rawBorderWidth = Math.max(0, options.borderWidth ?? 0);
+  const borderWidth = borderEnabled
+    ? Math.min(baseSize / 2, rawBorderWidth * (baseSize / sourceSize))
+    : 0;
+
+  return {
+    radius,
+    borderEnabled: borderEnabled && borderWidth > 0,
+    borderColor: options.borderColor ?? "#ffffff",
+    borderWidth,
+  };
+}
+
+function createRoundedRectPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+): void {
+  const safeRadius = Math.max(0, Math.min(radius, Math.min(width, height) / 2));
+  ctx.beginPath();
+  ctx.moveTo(x + safeRadius, y);
+  ctx.lineTo(x + width - safeRadius, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + safeRadius);
+  ctx.lineTo(x + width, y + height - safeRadius);
+  ctx.quadraticCurveTo(
+    x + width,
+    y + height,
+    x + width - safeRadius,
+    y + height
+  );
+  ctx.lineTo(x + safeRadius, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - safeRadius);
+  ctx.lineTo(x, y + safeRadius);
+  ctx.quadraticCurveTo(x, y, x + safeRadius, y);
+  ctx.closePath();
 }
 
 /**
@@ -373,6 +444,10 @@ export function renderSvg(options: SvgRenderOptions): string {
     padding = 0,
     outputSize,
     zendeskLocationMode = false,
+    cornerRadius = 0,
+    borderEnabled = false,
+    borderColor = "#ffffff",
+    borderWidth = 0,
   } = options;
 
   const {
@@ -408,19 +483,41 @@ export function renderSvg(options: SvgRenderOptions): string {
   const vbMinY = viewBoxParts[1] || 0;
   const vbWidth = viewBoxParts[2] || 24;
   const vbHeight = viewBoxParts[3] || 24;
+  const shape = normalizeShapeOptions(
+    { cornerRadius, borderEnabled, borderColor, borderWidth },
+    size
+  );
 
   // Render background (solid color or gradient)
   // In Zendesk location mode, skip background entirely for transparent SVG
-  let backgroundElement: string = "";
+  const bgElements: string[] = [];
   let gradientDef: string = "";
 
   if (!zendeskLocationMode) {
+    const fillValue = isGradient(backgroundColor)
+      ? `url(#bg-gradient-${Math.random().toString(36).substr(2, 9)})`
+      : backgroundColor;
+
     if (isGradient(backgroundColor)) {
-      const gradientId = `bg-gradient-${Math.random().toString(36).substr(2, 9)}`;
+      const gradientId = fillValue.slice(5, -1);
       gradientDef = gradientToSvgDef(backgroundColor, gradientId, size);
-      backgroundElement = `<rect width="${size}" height="${size}" fill="url(#${gradientId})"/>`;
-    } else {
-      backgroundElement = `<rect width="${size}" height="${size}" fill="${backgroundColor}"/>`;
+    }
+
+    const radiusAttr =
+      shape.radius > 0 ? ` rx="${shape.radius}" ry="${shape.radius}"` : "";
+    bgElements.push(
+      `<rect width="${size}" height="${size}"${radiusAttr} fill="${fillValue}"/>`
+    );
+
+    if (shape.borderEnabled) {
+      const inset = shape.borderWidth / 2;
+      const borderSize = Math.max(0, size - shape.borderWidth);
+      const borderRadius = Math.max(0, shape.radius - inset);
+      const borderRadiusAttr =
+        borderRadius > 0 ? ` rx="${borderRadius}" ry="${borderRadius}"` : "";
+      bgElements.push(
+        `<rect x="${inset}" y="${inset}" width="${borderSize}" height="${borderSize}"${borderRadiusAttr} fill="none" stroke="${shape.borderColor}" stroke-width="${shape.borderWidth}"/>`
+      );
     }
   }
 
@@ -451,8 +548,8 @@ export function renderSvg(options: SvgRenderOptions): string {
       const finalSize = outputSize ?? size;
 
       // Build background elements string (empty in Zendesk location mode)
-      const rasterBgElements = backgroundElement
-        ? `${gradientDef ? gradientDef + "\n" : ""}  ${backgroundElement}\n`
+      const rasterBgElements = bgElements.length
+        ? `${gradientDef ? gradientDef + "\n" : ""}  ${bgElements.join("\n  ")}\n`
         : "";
 
       return `<svg width="${finalSize}" height="${finalSize}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -565,12 +662,12 @@ ${rasterBgElements}  <image href="${href}" width="${scaledWidth}" height="${scal
   const finalSize = outputSize ?? size;
 
   // Build background elements string (empty in Zendesk location mode)
-  const bgElements = backgroundElement
-    ? `${gradientDef ? gradientDef + "\n" : ""}  ${backgroundElement}\n`
+  const backgroundElements = bgElements.length
+    ? `${gradientDef ? gradientDef + "\n" : ""}  ${bgElements.join("\n  ")}\n`
     : "";
 
   return `<svg width="${finalSize}" height="${finalSize}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
-${bgElements}  <g transform="${combinedTransform}"${groupAttrString}>
+${backgroundElements}  <g transform="${combinedTransform}"${groupAttrString}>
     ${adjustedContent}
   </g>
 </svg>`;
@@ -580,7 +677,18 @@ ${bgElements}  <g transform="${combinedTransform}"${groupAttrString}>
  * Create a canvas and render PNG
  */
 export async function renderPng(options: PngRenderOptions): Promise<Blob> {
-  const { icon, backgroundColor, iconColor, size, width, height } = options;
+  const {
+    icon,
+    backgroundColor,
+    iconColor,
+    size,
+    width,
+    height,
+    cornerRadius = 0,
+    borderEnabled = false,
+    borderColor = "#ffffff",
+    borderWidth = 0,
+  } = options;
 
   // Create canvas
   const canvas = document.createElement("canvas");
@@ -591,14 +699,36 @@ export async function renderPng(options: PngRenderOptions): Promise<Blob> {
     throw new Error("Failed to get canvas context");
   }
 
-  // Fill background (solid color or gradient)
+  // Fill background (solid color or gradient) and optional border
+  const shape = normalizeShapeOptions(
+    { cornerRadius, borderEnabled, borderColor, borderWidth },
+    Math.min(width, height)
+  );
   if (isGradient(backgroundColor)) {
     const gradient = createCanvasGradient(ctx, backgroundColor, width, height);
     ctx.fillStyle = gradient;
   } else {
     ctx.fillStyle = backgroundColor;
   }
-  ctx.fillRect(0, 0, width, height);
+  createRoundedRectPath(ctx, 0, 0, width, height, shape.radius);
+  ctx.fill();
+
+  if (shape.borderEnabled) {
+    const inset = shape.borderWidth / 2;
+    const borderWidthPx = Math.max(0, width - shape.borderWidth);
+    const borderHeightPx = Math.max(0, height - shape.borderWidth);
+    ctx.strokeStyle = shape.borderColor;
+    ctx.lineWidth = shape.borderWidth;
+    createRoundedRectPath(
+      ctx,
+      inset,
+      inset,
+      borderWidthPx,
+      borderHeightPx,
+      Math.max(0, shape.radius - inset)
+    );
+    ctx.stroke();
+  }
 
   // Render icon as SVG first, then draw to canvas
   // Use the size option to control icon size, but render at canvas size for quality
@@ -684,6 +814,10 @@ export async function renderRaster(
     format = "png",
     quality = 0.92,
     maxFileSize,
+    cornerRadius = 0,
+    borderEnabled = false,
+    borderColor = "#ffffff",
+    borderWidth = 0,
   } = options;
 
   // Create canvas
@@ -698,6 +832,10 @@ export async function renderRaster(
   // For JPEG, fill with background first since JPEG doesn't support transparency
   // For PNG/WebP with transparent background, clear to transparent
   if (format === "jpeg" || backgroundColor !== "transparent") {
+    const shape = normalizeShapeOptions(
+      { cornerRadius, borderEnabled, borderColor, borderWidth },
+      Math.min(width, height)
+    );
     if (isGradient(backgroundColor)) {
       const gradient = createCanvasGradient(
         ctx,
@@ -709,7 +847,25 @@ export async function renderRaster(
     } else {
       ctx.fillStyle = backgroundColor;
     }
-    ctx.fillRect(0, 0, width, height);
+    createRoundedRectPath(ctx, 0, 0, width, height, shape.radius);
+    ctx.fill();
+
+    if (shape.borderEnabled) {
+      const inset = shape.borderWidth / 2;
+      const borderWidthPx = Math.max(0, width - shape.borderWidth);
+      const borderHeightPx = Math.max(0, height - shape.borderWidth);
+      ctx.strokeStyle = shape.borderColor;
+      ctx.lineWidth = shape.borderWidth;
+      createRoundedRectPath(
+        ctx,
+        inset,
+        inset,
+        borderWidthPx,
+        borderHeightPx,
+        Math.max(0, shape.radius - inset)
+      );
+      ctx.stroke();
+    }
   }
 
   // Render icon as SVG first, then draw to canvas
@@ -818,6 +974,10 @@ export async function renderRasterFromImage(
     maxFileSize,
     colorOverride,
     originalColor,
+    cornerRadius = 0,
+    borderEnabled = false,
+    borderColor = "#ffffff",
+    borderWidth = 0,
   } = options;
 
   // Create canvas
@@ -830,13 +990,35 @@ export async function renderRasterFromImage(
   }
 
   // Fill background (solid color or gradient)
+  const shape = normalizeShapeOptions(
+    { cornerRadius, borderEnabled, borderColor, borderWidth },
+    Math.min(width, height)
+  );
   if (isGradient(backgroundColor)) {
     const gradient = createCanvasGradient(ctx, backgroundColor, width, height);
     ctx.fillStyle = gradient;
   } else {
     ctx.fillStyle = backgroundColor;
   }
-  ctx.fillRect(0, 0, width, height);
+  createRoundedRectPath(ctx, 0, 0, width, height, shape.radius);
+  ctx.fill();
+
+  if (shape.borderEnabled) {
+    const inset = shape.borderWidth / 2;
+    const borderWidthPx = Math.max(0, width - shape.borderWidth);
+    const borderHeightPx = Math.max(0, height - shape.borderWidth);
+    ctx.strokeStyle = shape.borderColor;
+    ctx.lineWidth = shape.borderWidth;
+    createRoundedRectPath(
+      ctx,
+      inset,
+      inset,
+      borderWidthPx,
+      borderHeightPx,
+      Math.max(0, shape.radius - inset)
+    );
+    ctx.stroke();
+  }
 
   // Load the image from data URL
   const img = await new Promise<HTMLImageElement>((resolve, reject) => {
@@ -960,6 +1142,14 @@ export interface ImageRenderOptions {
   colorOverride?: string | null;
   /** The detected dominant color from the original image (required if colorOverride is used) */
   originalColor?: string;
+  /** Corner radius percentage (0 = square, 100 = fully round) */
+  cornerRadius?: number;
+  /** Whether border is enabled */
+  borderEnabled?: boolean;
+  /** Border color */
+  borderColor?: string;
+  /** Border width in normalized artboard units */
+  borderWidth?: number;
 }
 
 /**
@@ -977,6 +1167,10 @@ export async function renderPngFromImage(
     height,
     colorOverride,
     originalColor,
+    cornerRadius = 0,
+    borderEnabled = false,
+    borderColor = "#ffffff",
+    borderWidth = 0,
   } = options;
 
   // Create canvas
@@ -989,13 +1183,35 @@ export async function renderPngFromImage(
   }
 
   // Fill background (solid color or gradient)
+  const shape = normalizeShapeOptions(
+    { cornerRadius, borderEnabled, borderColor, borderWidth },
+    Math.min(width, height)
+  );
   if (isGradient(backgroundColor)) {
     const gradient = createCanvasGradient(ctx, backgroundColor, width, height);
     ctx.fillStyle = gradient;
   } else {
     ctx.fillStyle = backgroundColor;
   }
-  ctx.fillRect(0, 0, width, height);
+  createRoundedRectPath(ctx, 0, 0, width, height, shape.radius);
+  ctx.fill();
+
+  if (shape.borderEnabled) {
+    const inset = shape.borderWidth / 2;
+    const borderWidthPx = Math.max(0, width - shape.borderWidth);
+    const borderHeightPx = Math.max(0, height - shape.borderWidth);
+    ctx.strokeStyle = shape.borderColor;
+    ctx.lineWidth = shape.borderWidth;
+    createRoundedRectPath(
+      ctx,
+      inset,
+      inset,
+      borderWidthPx,
+      borderHeightPx,
+      Math.max(0, shape.radius - inset)
+    );
+    ctx.stroke();
+  }
 
   // Load the image from data URL
   const img = await new Promise<HTMLImageElement>((resolve, reject) => {
@@ -1155,6 +1371,10 @@ export async function generateExportAssets(
         padding,
         outputSize: displaySize,
         zendeskLocationMode: isZendeskLocationSvg,
+        cornerRadius: state.cornerRadius,
+        borderEnabled: state.borderEnabled,
+        borderColor: state.borderColor,
+        borderWidth: state.borderWidth,
       });
       const blob = new Blob([svgString], { type: "image/svg+xml" });
       assets.set(variant.filename, blob);
@@ -1171,6 +1391,10 @@ export async function generateExportAssets(
           width: size,
           height: size,
           format: "png",
+          cornerRadius: state.cornerRadius,
+          borderEnabled: state.borderEnabled,
+          borderColor: state.borderColor,
+          borderWidth: state.borderWidth,
         });
         icoPngBlobs.push({ variant, blob });
       }
@@ -1186,6 +1410,10 @@ export async function generateExportAssets(
         format: variant.format,
         quality: variant.quality ? variant.quality / 100 : undefined,
         maxFileSize: variant.maxSize ? variant.maxSize * 1024 : undefined,
+        cornerRadius: state.cornerRadius,
+        borderEnabled: state.borderEnabled,
+        borderColor: state.borderColor,
+        borderWidth: state.borderWidth,
       });
       assets.set(variant.filename, blob);
     }


### PR DESCRIPTION
## Summary
- add corner radius and border controls to icon appearance and propagate through renderer/export/API paths
- redesign customization and canvas controls into accordion-based sections with updated preset handling
- implement compact color picker with collapsible swatch tray and controlled expansion in gradient editors
- move export preset selection/actions into preview panel and align UI interactions/tests
- update style preset data model/storage versioning for appearance fields and migration defaults

## Verification
- bun run build
- bun run lint
- bun run test:run
- bun run test:e2e

## Notes
- repository has moved to miguelcorderocollar/bundle-icon-generator; this PR targets that destination via the redirected remote