### PR TITLE
Debounce frame shape sliders and add debounce guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,12 @@ The following files are excluded from Next.js TypeScript compilation:
 - **Validates**: Icon selection, location requirements, color contrast
 - **Generates**: ZIP files with PNG and SVG assets
 
+### Debounced UI Inputs
+
+- **Rule**: Any high-frequency control (sliders, drag handles, rapid text inputs) that drives preview rendering or persisted generator state must use debounce.
+- **Pattern**: Keep immediate local UI state, debounce outbound updates (for example with `useDebouncedValue`), then commit to shared state/localStorage after the debounce delay.
+- **Coverage**: Apply this consistently to new customization controls (size, radius, border width, similar shape/effect values) to avoid jank and excessive re-renders.
+
 ## Zendesk-Specific Requirements
 
 ### Icon Sizes

--- a/components/CustomizationControlsPane.tsx
+++ b/components/CustomizationControlsPane.tsx
@@ -37,6 +37,8 @@ import { RestrictedStyleSelector } from "@/src/components/RestrictedStyleSelecto
 import type { RestrictedStyle } from "@/src/types/restriction";
 import { CustomImageColorOverride } from "@/src/components/CustomImageColorOverride";
 
+const SLIDER_DEBOUNCE_DELAY_MS = 300;
+
 export interface CustomizationControlsPaneProps {
   backgroundColor?: BackgroundValue;
   onBackgroundColorChange?: (color: BackgroundValue) => void;
@@ -219,13 +221,36 @@ export function CustomizationControlsPane({
 
   // Debounce icon size changes to prevent lag while dragging slider
   const [localIconSize, setLocalIconSize] = React.useState(iconSize);
-  const debouncedIconSize = useDebouncedValue(localIconSize, 300);
+  const debouncedIconSize = useDebouncedValue(
+    localIconSize,
+    SLIDER_DEBOUNCE_DELAY_MS
+  );
   const lastPropSizeRef = React.useRef(iconSize);
 
   // Debounce SVG icon size changes
   const [localSvgIconSize, setLocalSvgIconSize] = React.useState(svgIconSize);
-  const debouncedSvgIconSize = useDebouncedValue(localSvgIconSize, 300);
+  const debouncedSvgIconSize = useDebouncedValue(
+    localSvgIconSize,
+    SLIDER_DEBOUNCE_DELAY_MS
+  );
   const lastPropSvgSizeRef = React.useRef(svgIconSize);
+
+  // Debounce corner radius changes
+  const [localCornerRadius, setLocalCornerRadius] =
+    React.useState(cornerRadius);
+  const debouncedCornerRadius = useDebouncedValue(
+    localCornerRadius,
+    SLIDER_DEBOUNCE_DELAY_MS
+  );
+  const lastPropCornerRadiusRef = React.useRef(cornerRadius);
+
+  // Debounce border width changes
+  const [localBorderWidth, setLocalBorderWidth] = React.useState(borderWidth);
+  const debouncedBorderWidth = useDebouncedValue(
+    localBorderWidth,
+    SLIDER_DEBOUNCE_DELAY_MS
+  );
+  const lastPropBorderWidthRef = React.useRef(borderWidth);
 
   // Update parent when debounced value changes
   React.useEffect(() => {
@@ -245,6 +270,26 @@ export function CustomizationControlsPane({
     }
   }, [debouncedSvgIconSize, onSvgIconSizeChange]);
 
+  React.useEffect(() => {
+    if (
+      onCornerRadiusChange &&
+      debouncedCornerRadius !== lastPropCornerRadiusRef.current
+    ) {
+      lastPropCornerRadiusRef.current = debouncedCornerRadius;
+      onCornerRadiusChange(debouncedCornerRadius);
+    }
+  }, [debouncedCornerRadius, onCornerRadiusChange]);
+
+  React.useEffect(() => {
+    if (
+      onBorderWidthChange &&
+      debouncedBorderWidth !== lastPropBorderWidthRef.current
+    ) {
+      lastPropBorderWidthRef.current = debouncedBorderWidth;
+      onBorderWidthChange(debouncedBorderWidth);
+    }
+  }, [debouncedBorderWidth, onBorderWidthChange]);
+
   // Sync local state when prop changes externally
   React.useEffect(() => {
     if (iconSize !== lastPropSizeRef.current) {
@@ -260,12 +305,34 @@ export function CustomizationControlsPane({
     }
   }, [svgIconSize]);
 
+  React.useEffect(() => {
+    if (cornerRadius !== lastPropCornerRadiusRef.current) {
+      lastPropCornerRadiusRef.current = cornerRadius;
+      setLocalCornerRadius(cornerRadius);
+    }
+  }, [cornerRadius]);
+
+  React.useEffect(() => {
+    if (borderWidth !== lastPropBorderWidthRef.current) {
+      lastPropBorderWidthRef.current = borderWidth;
+      setLocalBorderWidth(borderWidth);
+    }
+  }, [borderWidth]);
+
   const handleIconSizeChange = (value: number) => {
     setLocalIconSize(value);
   };
 
   const handleSvgIconSizeChange = (value: number) => {
     setLocalSvgIconSize(value);
+  };
+
+  const handleCornerRadiusChange = (value: number) => {
+    setLocalCornerRadius(value);
+  };
+
+  const handleBorderWidthChange = (value: number) => {
+    setLocalBorderWidth(value);
   };
 
   return (
@@ -383,8 +450,8 @@ export function CustomizationControlsPane({
                   <EffectSlider
                     id="corner-radius"
                     label="Corner Radius"
-                    value={cornerRadius}
-                    onChange={onCornerRadiusChange}
+                    value={localCornerRadius}
+                    onChange={handleCornerRadiusChange}
                     min={0}
                     max={100}
                     step={1}
@@ -409,8 +476,8 @@ export function CustomizationControlsPane({
                     <EffectSlider
                       id="border-width"
                       label="Border Width"
-                      value={borderWidth}
-                      onChange={onBorderWidthChange}
+                      value={localBorderWidth}
+                      onChange={handleBorderWidthChange}
                       min={0}
                       max={40}
                       step={1}

--- a/src/components/__tests__/CustomizationControlsPane.test.tsx
+++ b/src/components/__tests__/CustomizationControlsPane.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { CustomizationControlsPane } from "../../../components/CustomizationControlsPane";
 import { usePresets } from "../../hooks/use-presets";
 import { useRestriction } from "../../contexts/RestrictionContext";
@@ -23,6 +23,40 @@ vi.mock("../StylePresetEditor", () => ({
 
 vi.mock("../PresetSettingsModal", () => ({
   PresetSettingsModal: () => null,
+}));
+
+vi.mock("../EffectSlider", () => ({
+  EffectSlider: ({
+    id,
+    label,
+    value,
+    onChange,
+    min,
+    max,
+    step,
+  }: {
+    id: string;
+    label: string;
+    value: number;
+    onChange: (value: number) => void;
+    min?: number;
+    max?: number;
+    step?: number;
+  }) => (
+    <label htmlFor={id}>
+      <span>{label}</span>
+      <input
+        id={id}
+        data-testid={`slider-${id}`}
+        type="range"
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(event) => onChange(Number(event.target.value))}
+      />
+    </label>
+  ),
 }));
 
 const pngPreset: ExportPreset = {
@@ -135,5 +169,54 @@ describe("CustomizationControlsPane", () => {
 
     expect(screen.getByText("PNG Size")).toBeInTheDocument();
     expect(screen.getByText("SVG Size")).toBeInTheDocument();
+  });
+
+  it("debounces corner radius and border width slider updates", () => {
+    vi.useFakeTimers();
+
+    try {
+      mockPresets("svg-mixed");
+      const onCornerRadiusChange = vi.fn();
+      const onBorderWidthChange = vi.fn();
+
+      render(
+        <CustomizationControlsPane
+          cornerRadius={16}
+          onCornerRadiusChange={onCornerRadiusChange}
+          borderEnabled
+          onBorderEnabledChange={vi.fn()}
+          borderWidth={6}
+          onBorderWidthChange={onBorderWidthChange}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /frame shape/i }));
+
+      fireEvent.change(screen.getByTestId("slider-corner-radius"), {
+        target: { value: "42" },
+      });
+      fireEvent.change(screen.getByTestId("slider-border-width"), {
+        target: { value: "10" },
+      });
+
+      expect(onCornerRadiusChange).not.toHaveBeenCalled();
+      expect(onBorderWidthChange).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(299);
+      });
+      expect(onCornerRadiusChange).not.toHaveBeenCalled();
+      expect(onBorderWidthChange).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(onCornerRadiusChange).toHaveBeenCalledTimes(1);
+      expect(onCornerRadiusChange).toHaveBeenCalledWith(42);
+      expect(onBorderWidthChange).toHaveBeenCalledTimes(1);
+      expect(onBorderWidthChange).toHaveBeenCalledWith(10);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add debounce handling for `cornerRadius` and `borderWidth` sliders in `CustomizationControlsPane`
- keep immediate local slider feedback while debouncing parent state commits
- add a regression test that verifies frame-shape slider callbacks fire after debounce delay
- document debounce expectations for high-frequency inputs in `AGENTS.md`

## Validation
- bun run build
- bun run lint
- bun run test:run
- bun run format
- bun run test:e2e (63 passed)