### PR TITLE
feat: demonstrate WebMCP tools for icon generation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/src/utils/restriction-codec";
 import { importUserPresets } from "@/src/utils/preset-storage";
 import type { PresetImportResult } from "@/src/types/preset";
+import { WebMcpGeneratorBridge } from "@/src/components/WebMcpGeneratorBridge";
 
 export default function Home() {
   const { state, actions } = useIconGenerator();
@@ -189,6 +190,11 @@ export default function Home() {
           <div>
             <div className="flex items-center gap-2">
               <h1 className="text-2xl font-semibold">{APP_NAME}</h1>
+              <WebMcpGeneratorBridge
+                state={state}
+                actions={actions}
+                canvasState={canvasState}
+              />
               {!isRestrictionLoading && isRestricted ? (
                 <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
                   <Lock className="h-3 w-3" />

--- a/app/webmcp/page.tsx
+++ b/app/webmcp/page.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import * as React from "react";
+import Image from "next/image";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Check,
+  CircleAlert,
+  Code2,
+  ExternalLink,
+  Play,
+  Sparkles,
+  Terminal,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  createWebMcpTools,
+  getDocumentModelContext,
+  registerWebMcpTools,
+  type GeneratedIconSvgResult,
+  type WebMcpRegistration,
+  type WebMcpToolDefinition,
+} from "@/src/utils/webmcp";
+
+type WebMcpStatus = "checking" | "ready" | "unavailable" | "error";
+
+const webMcpTools = createWebMcpTools();
+const generateTool = webMcpTools.find(
+  (tool) => tool.name === "generate_icon_svg"
+);
+
+const defaultGenerationInput = {
+  iconId: "feather-star",
+  backgroundColor: "#17494d",
+  iconColor: "#ffffff",
+  size: 128,
+  padding: 8,
+};
+
+function ToolRow({ tool }: { tool: WebMcpToolDefinition }) {
+  return (
+    <div className="flex items-start gap-3 border-t border-white/10 py-4 first:border-t-0 first:pt-0 last:pb-0">
+      <div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-cyan-300/10 text-cyan-200">
+        <Code2 className="size-3.5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <code className="text-sm font-semibold text-white">{tool.name}</code>
+          <Badge className="border-cyan-200/20 bg-cyan-200/10 text-[10px] text-cyan-100">
+            read-only
+          </Badge>
+        </div>
+        <p className="mt-1 text-xs leading-5 text-slate-400">
+          {tool.description}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function StatusMessage({ status }: { status: WebMcpStatus }) {
+  if (status === "ready") {
+    return (
+      <span className="inline-flex items-center gap-2 text-sm text-emerald-300">
+        <span className="size-2 rounded-full bg-emerald-300 shadow-[0_0_14px_rgba(110,231,183,0.9)]" />
+        WebMCP detected
+      </span>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <span className="inline-flex items-center gap-2 text-sm text-rose-300">
+        <CircleAlert className="size-4" />
+        Registration failed
+      </span>
+    );
+  }
+
+  if (status === "unavailable") {
+    return (
+      <span className="inline-flex items-center gap-2 text-sm text-amber-200">
+        <CircleAlert className="size-4" />
+        WebMCP is not available in this browser
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2 text-sm text-slate-300">
+      <span className="size-2 animate-pulse rounded-full bg-slate-300" />
+      Checking browser support...
+    </span>
+  );
+}
+
+export default function WebMcpPage() {
+  const [status, setStatus] = React.useState<WebMcpStatus>("checking");
+  const [registration, setRegistration] =
+    React.useState<WebMcpRegistration | null>(null);
+  const [query, setQuery] = React.useState(defaultGenerationInput.iconId);
+  const [result, setResult] = React.useState<GeneratedIconSvgResult | null>(
+    null
+  );
+  const [isRunning, setIsRunning] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let disposed = false;
+    let activeRegistration: WebMcpRegistration | null = null;
+
+    async function registerTools() {
+      const modelContext = getDocumentModelContext();
+      if (!modelContext) {
+        setStatus("unavailable");
+        return;
+      }
+
+      try {
+        const nextRegistration = await registerWebMcpTools(modelContext);
+        if (disposed) {
+          nextRegistration.dispose();
+          return;
+        }
+        activeRegistration = nextRegistration;
+        setRegistration(nextRegistration);
+        setStatus("ready");
+      } catch {
+        if (!disposed) {
+          setStatus("error");
+        }
+      }
+    }
+
+    void registerTools();
+
+    return () => {
+      disposed = true;
+      activeRegistration?.dispose();
+    };
+  }, []);
+
+  async function runGenerationTool() {
+    if (!generateTool) {
+      setError("The generation tool is not registered.");
+      return;
+    }
+
+    setIsRunning(true);
+    setError(null);
+    try {
+      const toolResult = await generateTool.execute(
+        { ...defaultGenerationInput, iconId: query.trim() },
+        { signal: new AbortController().signal }
+      );
+      setResult(toolResult as GeneratedIconSvgResult);
+    } catch (toolError) {
+      setResult(null);
+      setError(
+        toolError instanceof Error ? toolError.message : "Tool call failed."
+      );
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  const previewUrl = result
+    ? "data:image/svg+xml;charset=utf-8," + encodeURIComponent(result.svg)
+    : null;
+
+  return (
+    <main className="min-h-screen overflow-hidden bg-[#071c24] text-slate-100">
+      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_15%_10%,rgba(33,164,165,0.22),transparent_32%),radial-gradient(circle_at_90%_85%,rgba(243,171,73,0.14),transparent_30%)]" />
+      <div className="relative mx-auto max-w-6xl px-5 py-6 md:px-10 md:py-10">
+        <nav className="flex items-center justify-between">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-sm text-slate-400 transition-colors hover:text-white"
+          >
+            <ArrowLeft className="size-4" />
+            Icon generator
+          </Link>
+          <Badge className="border-amber-200/25 bg-amber-200/10 px-3 py-1 text-[10px] tracking-[0.18em] text-amber-100 uppercase">
+            WebMCP demo
+          </Badge>
+        </nav>
+
+        <section className="grid gap-8 pb-12 pt-16 md:grid-cols-[1.2fr_0.8fr] md:items-end md:pt-24">
+          <div>
+            <p className="mb-5 flex items-center gap-2 text-xs font-medium tracking-[0.24em] text-cyan-200 uppercase">
+              <Sparkles className="size-4" />
+              Tools in the tab
+            </p>
+            <h1 className="max-w-3xl text-4xl leading-[1.05] font-semibold tracking-[-0.04em] text-white md:text-7xl">
+              Give an agent the controls, not a screenshot puzzle.
+            </h1>
+            <p className="mt-6 max-w-2xl text-base leading-7 text-slate-400 md:text-lg">
+              This page registers three read-only tools with the browser&apos;s
+              WebMCP model context. The tools call the same icon catalog and
+              renderer as the app, so an agent can search, inspect, and generate
+              an SVG while you keep the page in view.
+            </p>
+          </div>
+
+          <Card className="border-white/10 bg-white/[0.06] text-white shadow-2xl shadow-cyan-950/30 backdrop-blur">
+            <CardHeader className="gap-4">
+              <div className="flex items-center justify-between">
+                <CardTitle className="font-mono text-sm font-medium tracking-tight">
+                  document.modelContext
+                </CardTitle>
+                <Terminal className="size-4 text-cyan-200" />
+              </div>
+              <CardDescription className="text-slate-400">
+                The top-level document is the tool owner.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-3">
+                <StatusMessage status={status} />
+                {registration ? (
+                  <p className="mt-2 text-xs text-slate-500">
+                    {registration.toolNames.length} tools registered for this
+                    page
+                  </p>
+                ) : null}
+              </div>
+              <p className="mt-4 text-xs leading-5 text-slate-500">
+                ChatGPT site tools and compatible browser agents can discover
+                these definitions when WebMCP is enabled.
+              </p>
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="grid gap-5 md:grid-cols-[0.85fr_1.15fr]">
+          <Card className="border-white/10 bg-white/[0.055] text-white shadow-xl shadow-black/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-lg">Registered tools</CardTitle>
+              <CardDescription className="text-slate-400">
+                Narrow inputs. No downloads. No page mutations.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div>
+                {webMcpTools.map((tool) => (
+                  <ToolRow key={tool.name} tool={tool} />
+                ))}
+              </div>
+              <div className="mt-7 rounded-lg border border-cyan-200/10 bg-cyan-200/[0.05] p-4">
+                <p className="font-mono text-xs leading-6 text-cyan-100/80">
+                  {'registerTool({ name: "generate_icon_svg" })'}
+                </p>
+                <p className="mt-2 text-xs leading-5 text-slate-500">
+                  SVG responses are marked as untrusted content so a calling
+                  agent can handle them with care.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="border-amber-200/15 bg-[#102d34] text-white shadow-xl shadow-black/20">
+            <CardHeader className="border-b border-white/10">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <CardTitle className="text-lg">
+                    Try the generation tool
+                  </CardTitle>
+                  <CardDescription className="mt-2 text-slate-400">
+                    This button invokes the exact handler an agent would call.
+                  </CardDescription>
+                </div>
+                <div className="hidden rounded-full border border-amber-200/20 bg-amber-200/10 p-2 text-amber-100 sm:block">
+                  <Play className="size-4" />
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-5 pt-6">
+              <div className="space-y-2">
+                <label
+                  htmlFor="webmcp-icon-id"
+                  className="text-xs font-medium text-slate-300"
+                >
+                  Icon ID
+                </label>
+                <div className="flex gap-2">
+                  <Input
+                    id="webmcp-icon-id"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    className="border-white/10 bg-black/20 text-white placeholder:text-slate-600"
+                    placeholder="feather-star"
+                  />
+                  <Button
+                    onClick={runGenerationTool}
+                    disabled={isRunning || !query.trim()}
+                    className="shrink-0 bg-amber-200 text-[#17262b] hover:bg-amber-100"
+                  >
+                    {isRunning ? "Running..." : "Run tool"}
+                  </Button>
+                </div>
+              </div>
+
+              {error ? (
+                <div className="rounded-lg border border-rose-300/20 bg-rose-300/10 p-4 text-sm text-rose-100">
+                  {error}
+                </div>
+              ) : null}
+
+              <div className="grid min-h-72 place-items-center overflow-hidden rounded-xl border border-white/10 bg-[linear-gradient(135deg,#17494d,#0b252d)] p-8">
+                {previewUrl ? (
+                  <div className="grid size-48 place-items-center rounded-2xl bg-white/10 p-4 shadow-2xl shadow-black/20">
+                    <Image
+                      src={previewUrl}
+                      alt={result?.icon.name ?? "Generated icon"}
+                      width={192}
+                      height={192}
+                      unoptimized
+                      className="size-full"
+                    />
+                  </div>
+                ) : (
+                  <div className="max-w-xs text-center">
+                    <div className="mx-auto mb-4 grid size-12 place-items-center rounded-xl border border-dashed border-white/20 text-slate-500">
+                      <Code2 className="size-5" />
+                    </div>
+                    <p className="text-sm text-slate-400">
+                      Run the tool to render an SVG from the bundled catalog.
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {result ? (
+                <div className="grid gap-3 text-xs text-slate-400 sm:grid-cols-3">
+                  <div>
+                    <p className="text-slate-600 uppercase">Icon</p>
+                    <p className="mt-1 font-mono text-slate-200">
+                      {result.icon.id}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-slate-600 uppercase">Output</p>
+                    <p className="mt-1 font-mono text-slate-200">
+                      {result.settings.outputSize}px SVG
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-slate-600 uppercase">Contract</p>
+                    <p className="mt-1 inline-flex items-center gap-1 font-mono text-emerald-300">
+                      <Check className="size-3" />v{result.apiVersion}
+                    </p>
+                  </div>
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="mt-5 grid gap-5 md:grid-cols-2">
+          <Card className="border-white/10 bg-black/15 text-white">
+            <CardHeader>
+              <CardTitle className="text-base">Ask ChatGPT to use it</CardTitle>
+              <CardDescription className="text-slate-400">
+                Open this deployed route in the built-in browser, then ask for a
+                specific icon search or SVG generation.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="rounded-lg border border-white/10 bg-black/20 p-4 font-mono text-xs leading-6 text-slate-300">
+                &quot;Use the site tools to find a Feather star icon and
+                generate it with a teal background.&quot;
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="border-white/10 bg-black/15 text-white">
+            <CardHeader>
+              <CardTitle className="text-base">
+                Read the implementation
+              </CardTitle>
+              <CardDescription className="text-slate-400">
+                The demo is intentionally small so the tool contract is easy to
+                inspect in a draft PR.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-3">
+                <Button
+                  variant="outline"
+                  asChild
+                  className="border-white/15 bg-transparent text-white hover:bg-white/10 hover:text-white"
+                >
+                  <a
+                    href="https://github.com/miguelcorderocollar/bundle-icon-generator/blob/codex/webmcp-demo/src/utils/webmcp.ts"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <ExternalLink className="size-4" />
+                    Tool source
+                  </a>
+                </Button>
+                <Button
+                  variant="outline"
+                  asChild
+                  className="border-white/15 bg-transparent text-white hover:bg-white/10 hover:text-white"
+                >
+                  <a
+                    href="https://learn.chatgpt.com/docs/webmcp"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    ChatGPT guide
+                    <ExternalLink className="size-4" />
+                  </a>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -1,0 +1,22 @@
+# WebMCP demo
+
+The /webmcp route demonstrates how the icon generator can expose narrow, read-only tools to a browser agent.
+
+The page registers these tools on the top-level document when document.modelContext.registerTool is available:
+
+- search_icons finds icons by text and pack.
+- get_icon returns metadata and source SVG for one icon.
+- generate_icon_svg validates customization settings and returns a generated SVG.
+
+The handlers use the existing client-side catalog and renderer. They do not read React state, trigger downloads, or upload files. SVG-bearing results are marked with WebMCP's untrustedContentHint annotation.
+
+## Try it with ChatGPT
+
+1. Open the deployed /webmcp route in the ChatGPT desktop app's built-in browser.
+2. Use a model with site tools enabled, such as GPT-5.6 Sol or GPT-5.6 Terra.
+3. Ask ChatGPT to search for an icon or generate an SVG with a specific color.
+4. Inspect the available site tools and the recent tool call in the browser UI.
+
+ChatGPT currently discovers JavaScript-registered tools in the top-level page. It does not discover declarative tools or tools registered inside iframes. WebMCP support is rollout-dependent, so the page also shows a clear unsupported state and keeps the normal app behavior separate.
+
+The demo is intentionally not an MCP server. A remote MCP server would be useful when the app does not have an open page. WebMCP is a better fit for this local-first workflow because the agent and user can work with the same live tab.

--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -1,6 +1,6 @@
 # WebMCP demo
 
-The /webmcp route demonstrates how the icon generator can expose narrow, read-only tools to a browser agent.
+The main generator page exposes a complete, stateful WebMCP workflow. The /webmcp route remains a small test bench for inspecting the underlying read-only API.
 
 The page registers these tools on the top-level document when document.modelContext.registerTool is available:
 
@@ -10,12 +10,27 @@ The page registers these tools on the top-level document when document.modelCont
 
 The handlers use the existing client-side catalog and renderer. They do not read React state, trigger downloads, or upload files. SVG-bearing results are marked with WebMCP's untrustedContentHint annotation.
 
+## Main generator tools
+
+When the main page is open in a compatible browser, it additionally registers:
+
+- inspect_generator_state reads the selected icon, current customization, available locations, and export presets.
+- configure_generator selects an icon and applies colors, gradients, sizes, borders, locations, style presets, and export presets.
+- render_current_icon renders the current visible configuration without downloading anything.
+- export_icon_bundle generates and downloads the configured bundle. This is the only tool with a download side effect.
+
+The tools call the same React state actions, export validation, renderer, and preset data used by the visible UI. This keeps the agent contract aligned with the product instead of creating a parallel mock workflow.
+
 ## Try it with ChatGPT
 
-1. Open the deployed /webmcp route in the ChatGPT desktop app's built-in browser.
+1. Open the deployed main route in the ChatGPT desktop app's built-in browser.
 2. Use a model with site tools enabled, such as GPT-5.6 Sol or GPT-5.6 Terra.
-3. Ask ChatGPT to search for an icon or generate an SVG with a specific color.
-4. Inspect the available site tools and the recent tool call in the browser UI.
+3. Ask ChatGPT to inspect the generator, choose an icon and customization, render it, and export it.
+4. Approve the download when the browser asks for confirmation.
+
+Example request:
+
+> Use the site tools to find a Feather star icon, select it, set a teal background and white icon, choose the Zendesk App preset, render the current icon, then export the bundle.
 
 ChatGPT currently discovers JavaScript-registered tools in the top-level page. It does not discover declarative tools or tools registered inside iframes. WebMCP support is rollout-dependent, so the page also shows a clear unsupported state and keeps the normal app behavior separate.
 

--- a/e2e/webmcp.spec.ts
+++ b/e2e/webmcp.spec.ts
@@ -49,4 +49,45 @@ test.describe("WebMCP demo", () => {
       "generate_icon_svg",
     ]);
   });
+
+  test("exposes the complete workflow on the main generator page", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      const testWindow = window as Window & {
+        __registeredWebMcpTools: Array<{ name: string }>;
+      };
+      testWindow.__registeredWebMcpTools = [];
+
+      Object.defineProperty(document, "modelContext", {
+        configurable: true,
+        value: {
+          registerTool: async (tool: { name: string }) => {
+            testWindow.__registeredWebMcpTools.push(tool);
+          },
+        },
+      });
+    });
+    await page.goto("/");
+
+    await expect(page.getByTestId("webmcp-main-status")).toHaveText(
+      /Agent ready · 7 tools/
+    );
+    const registeredNames = await page.evaluate(() => {
+      const testWindow = window as Window & {
+        __registeredWebMcpTools: Array<{ name: string }>;
+      };
+      return testWindow.__registeredWebMcpTools.map((tool) => tool.name);
+    });
+
+    expect(registeredNames).toEqual([
+      "search_icons",
+      "get_icon",
+      "generate_icon_svg",
+      "inspect_generator_state",
+      "configure_generator",
+      "render_current_icon",
+      "export_icon_bundle",
+    ]);
+  });
 });

--- a/e2e/webmcp.spec.ts
+++ b/e2e/webmcp.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("WebMCP demo", () => {
+  test("renders the manual tool call in a regular browser", async ({
+    page,
+  }) => {
+    await page.goto("/webmcp");
+
+    await expect(
+      page.getByText("WebMCP is not available in this browser")
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Run tool" }).click();
+
+    await expect(page.getByAltText("Star")).toBeVisible();
+    await expect(page.getByText("v0.1.0")).toBeVisible();
+  });
+
+  test("registers tools when a WebMCP model context is present", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      const testWindow = window as Window & {
+        __registeredWebMcpTools: Array<{ name: string }>;
+      };
+      testWindow.__registeredWebMcpTools = [];
+
+      Object.defineProperty(document, "modelContext", {
+        configurable: true,
+        value: {
+          registerTool: async (tool: { name: string }) => {
+            testWindow.__registeredWebMcpTools.push(tool);
+          },
+        },
+      });
+    });
+    await page.goto("/webmcp");
+
+    await expect(page.getByText("WebMCP detected")).toBeVisible();
+    const registeredNames = await page.evaluate(() => {
+      const testWindow = window as Window & {
+        __registeredWebMcpTools: Array<{ name: string }>;
+      };
+      return testWindow.__registeredWebMcpTools.map((tool) => tool.name);
+    });
+
+    expect(registeredNames).toEqual([
+      "search_icons",
+      "get_icon",
+      "generate_icon_svg",
+    ]);
+  });
+});

--- a/src/components/WebMcpGeneratorBridge.tsx
+++ b/src/components/WebMcpGeneratorBridge.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import * as React from "react";
+import type { CanvasEditorState } from "../types/canvas";
+import type {
+  IconGeneratorActions,
+  IconGeneratorState,
+} from "../hooks/use-icon-generator";
+import { usePresets } from "../hooks/use-presets";
+import { useRestriction } from "../contexts/RestrictionContext";
+import { getDocumentModelContext, registerWebMcpTools } from "../utils/webmcp";
+import {
+  createGeneratorWebMcpTools,
+  type WebMcpGeneratorBindings,
+} from "../utils/webmcp-generator";
+
+interface WebMcpGeneratorBridgeProps {
+  state: IconGeneratorState;
+  actions: IconGeneratorActions;
+  canvasState: CanvasEditorState;
+}
+
+type RegistrationStatus = "checking" | "ready" | "unavailable" | "error";
+
+export function WebMcpGeneratorBridge({
+  state,
+  actions,
+  canvasState,
+}: WebMcpGeneratorBridgeProps) {
+  const {
+    exportPresets,
+    selectedExportPresetId,
+    stylePresets,
+    selectedStylePresetId,
+    selectExportPreset,
+    selectStylePreset,
+  } = usePresets();
+  const restriction = useRestriction();
+  const stateRef = React.useRef(state);
+  const canvasStateRef = React.useRef(canvasState);
+  const exportPresetsRef = React.useRef(exportPresets);
+  const selectedExportPresetIdRef = React.useRef(selectedExportPresetId);
+  const stylePresetsRef = React.useRef(stylePresets);
+  const selectedStylePresetIdRef = React.useRef(selectedStylePresetId);
+  const restrictionRef = React.useRef(restriction);
+  const [status, setStatus] = React.useState<RegistrationStatus>("checking");
+  const [toolCount, setToolCount] = React.useState(0);
+
+  React.useEffect(() => {
+    stateRef.current = state;
+    canvasStateRef.current = canvasState;
+    exportPresetsRef.current = exportPresets;
+    selectedExportPresetIdRef.current = selectedExportPresetId;
+    stylePresetsRef.current = stylePresets;
+    selectedStylePresetIdRef.current = selectedStylePresetId;
+    restrictionRef.current = restriction;
+  }, [
+    canvasState,
+    exportPresets,
+    restriction,
+    selectedExportPresetId,
+    selectedStylePresetId,
+    state,
+    stylePresets,
+  ]);
+
+  const bindings = React.useMemo<WebMcpGeneratorBindings>(
+    () => ({
+      getState: () => stateRef.current,
+      getCanvasState: () => canvasStateRef.current,
+      getExportPresets: () =>
+        restrictionRef.current.allowedExportPresets ?? exportPresetsRef.current,
+      getSelectedExportPresetId: () => selectedExportPresetIdRef.current,
+      getStylePresets: () => stylePresetsRef.current,
+      getSelectedStylePresetId: () => selectedStylePresetIdRef.current,
+      isIconPackAllowed: (pack) =>
+        restrictionRef.current.isIconPackAllowed(pack),
+      isExportPresetAllowed: (preset) =>
+        restrictionRef.current.isExportPresetAllowed(preset.id),
+      isRestricted: () => restrictionRef.current.isRestricted,
+      getAllowedStyles: () => restrictionRef.current.allowedStyles,
+      actions,
+      selectExportPreset,
+      selectStylePreset,
+    }),
+    [actions, selectExportPreset, selectStylePreset]
+  );
+
+  React.useEffect(() => {
+    const modelContext = getDocumentModelContext();
+    if (!modelContext) {
+      setStatus("unavailable");
+      return;
+    }
+
+    let disposed = false;
+    const registrationPromise = registerWebMcpTools(
+      modelContext,
+      createGeneratorWebMcpTools(bindings)
+    );
+
+    registrationPromise
+      .then((registration) => {
+        if (disposed) {
+          registration.dispose();
+          return;
+        }
+        setToolCount(registration.toolNames.length);
+        setStatus("ready");
+      })
+      .catch(() => {
+        if (!disposed) {
+          setStatus("error");
+        }
+      });
+
+    return () => {
+      disposed = true;
+      void registrationPromise
+        .then((registration) => registration.dispose())
+        .catch(() => undefined);
+    };
+  }, [bindings]);
+
+  if (status !== "ready") {
+    return null;
+  }
+
+  return (
+    <span
+      data-testid="webmcp-main-status"
+      className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-300"
+      title="This page exposes icon search, configuration, rendering, and export tools."
+    >
+      <span
+        className="size-1.5 rounded-full bg-emerald-500"
+        aria-hidden="true"
+      />
+      Agent ready · {toolCount} tools
+    </span>
+  );
+}

--- a/src/utils/__tests__/webmcp-generator.test.ts
+++ b/src/utils/__tests__/webmcp-generator.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IconMetadata } from "../../types/icon";
+import type { ExportPreset } from "../../types/preset";
+import type { RestrictedStyle } from "../../types/restriction";
+import type {
+  IconGeneratorActions,
+  IconGeneratorState,
+} from "../../hooks/use-icon-generator";
+import {
+  createGeneratorWebMcpTools,
+  type WebMcpGeneratorBindings,
+} from "../webmcp-generator";
+import type { WebMcpToolDefinition } from "../webmcp";
+
+const featherStar: IconMetadata = {
+  id: "feather-star",
+  name: "Star",
+  pack: "feather",
+  svg: '<svg viewBox="0 0 24 24"><path d="M1 1" /></svg>',
+  keywords: ["star", "favorite"],
+};
+
+const zendeskPreset: ExportPreset = {
+  id: "zendesk-app",
+  name: "Zendesk App",
+  description: "Icon bundle for Zendesk marketplace apps",
+  isBuiltIn: true,
+  variants: [
+    {
+      filename: "logo.png",
+      width: 320,
+      height: 320,
+      format: "png",
+    },
+  ],
+};
+
+const mocks = vi.hoisted(() => ({
+  renderSvg: vi.fn(() => '<svg viewBox="0 0 128 128"><path /></svg>'),
+  downloadFile: vi.fn(),
+  generateExportDownloadPayload: vi.fn(),
+  validateExport: vi.fn(() => ({ valid: true, errors: [], warnings: [] })),
+}));
+
+vi.mock("../icon-catalog", () => ({
+  getIconById: vi.fn(async (id: string) =>
+    id === featherStar.id ? featherStar : null
+  ),
+  searchIcons: vi.fn(async () => [featherStar]),
+  filterIconsByPack: vi.fn(async (icons: IconMetadata[]) => icons),
+}));
+
+vi.mock("../renderer", () => ({ renderSvg: mocks.renderSvg }));
+
+vi.mock("../export-controller", () => ({
+  downloadFile: mocks.downloadFile,
+  generateExportDownloadPayload: mocks.generateExportDownloadPayload,
+  validateExport: mocks.validateExport,
+}));
+
+function createState(): IconGeneratorState {
+  return {
+    selectedLocations: [],
+    selectedIconId: featherStar.id,
+    backgroundColor: "#063940",
+    iconColor: "#ffffff",
+    searchQuery: "",
+    selectedPack: "all",
+    iconSize: 123,
+    svgIconSize: 123,
+    cornerRadius: 0,
+    borderEnabled: false,
+    borderColor: "#ffffff",
+    borderWidth: 6,
+  };
+}
+
+function createBindings(state: IconGeneratorState = createState()): {
+  bindings: WebMcpGeneratorBindings;
+  actions: Record<keyof IconGeneratorActions, ReturnType<typeof vi.fn>>;
+} {
+  const actions = {
+    setSelectedLocations: vi.fn(),
+    setSelectedIconId: vi.fn(),
+    setBackgroundColor: vi.fn(),
+    setIconColor: vi.fn(),
+    setSearchQuery: vi.fn(),
+    setSelectedPack: vi.fn(),
+    setIconSize: vi.fn(),
+    setSvgIconSize: vi.fn(),
+    setCornerRadius: vi.fn(),
+    setBorderEnabled: vi.fn(),
+    setBorderColor: vi.fn(),
+    setBorderWidth: vi.fn(),
+    setBorderStyle: vi.fn(),
+  } as Record<keyof IconGeneratorActions, ReturnType<typeof vi.fn>>;
+
+  return {
+    actions,
+    bindings: {
+      getState: () => state,
+      getCanvasState: () => ({
+        layers: [],
+        selectedLayerId: null,
+        backgroundColor: state.backgroundColor,
+      }),
+      getExportPresets: () => [zendeskPreset],
+      getSelectedExportPresetId: () => zendeskPreset.id,
+      getStylePresets: () => [],
+      getSelectedStylePresetId: () => null,
+      isIconPackAllowed: () => true,
+      isExportPresetAllowed: () => true,
+      isRestricted: () => false,
+      getAllowedStyles: () => [],
+      actions: actions as unknown as IconGeneratorActions,
+      selectExportPreset: vi.fn(),
+      selectStylePreset: vi.fn(),
+    },
+  };
+}
+
+function findTool(tools: WebMcpToolDefinition[], name: string) {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error("Tool " + name + " was not created");
+  }
+  return tool;
+}
+
+function createExecutionOptions(): { signal: AbortSignal } {
+  return { signal: new AbortController().signal };
+}
+
+describe("generator WebMCP tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.generateExportDownloadPayload.mockResolvedValue({
+      blob: new Blob(["zip"]),
+      filename: "zendesk-app-icons.zip",
+      isZip: true,
+      metadata: {
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        iconId: featherStar.id,
+        iconName: featherStar.name,
+        customization: {
+          backgroundColor: "#063940",
+          iconColor: "#ffffff",
+          iconSize: 123,
+        },
+        locations: [],
+        variants: ["logo.png"],
+      },
+      filenames: ["logo.png"],
+    });
+  });
+
+  it("exposes the full main-page workflow", () => {
+    const { bindings } = createBindings();
+    expect(
+      createGeneratorWebMcpTools(bindings).map((tool) => tool.name)
+    ).toEqual([
+      "search_icons",
+      "get_icon",
+      "generate_icon_svg",
+      "inspect_generator_state",
+      "configure_generator",
+      "render_current_icon",
+      "export_icon_bundle",
+    ]);
+  });
+
+  it("configures the visible generator state", async () => {
+    const { bindings, actions } = createBindings();
+    const tool = findTool(
+      createGeneratorWebMcpTools(bindings),
+      "configure_generator"
+    );
+
+    const result = (await tool.execute(
+      {
+        iconId: featherStar.id,
+        pack: "feather",
+        locations: ["top_bar", "nav_bar"],
+        backgroundColor: "#17494d",
+        iconColor: "#ffffff",
+        iconSize: 256,
+        exportPresetId: zendeskPreset.id,
+      },
+      createExecutionOptions()
+    )) as { applied: { locations: string[]; pack: string; iconId: string } };
+
+    expect(actions.setSelectedIconId).toHaveBeenCalledWith(featherStar.id);
+    expect(actions.setSelectedPack).toHaveBeenCalledWith("feather");
+    expect(actions.setSelectedLocations).toHaveBeenCalledWith([
+      "top_bar",
+      "nav_bar",
+    ]);
+    expect(actions.setBackgroundColor).toHaveBeenCalledWith("#17494d");
+    expect(actions.setIconSize).toHaveBeenCalledWith(256);
+    expect(result.applied).toMatchObject({
+      iconId: featherStar.id,
+      pack: "feather",
+      locations: ["top_bar", "nav_bar"],
+    });
+  });
+
+  it("renders the current visible configuration", async () => {
+    const { bindings } = createBindings();
+    const tool = findTool(
+      createGeneratorWebMcpTools(bindings),
+      "render_current_icon"
+    );
+
+    const result = (await tool.execute({}, createExecutionOptions())) as {
+      svg: string;
+      settings: { size: number };
+    };
+
+    expect(mocks.renderSvg).toHaveBeenCalledWith(
+      expect.objectContaining({ size: 123, iconColor: "#ffffff" })
+    );
+    expect(result).toMatchObject({
+      svg: expect.stringContaining("<svg"),
+      settings: { size: 123 },
+    });
+  });
+
+  it("keeps restricted customization behind allowed style names", async () => {
+    const { bindings, actions } = createBindings();
+    const restrictedStyle: RestrictedStyle = {
+      name: "Brand teal",
+      backgroundColor: "#17494d",
+      iconColor: "#ffffff",
+    };
+    bindings.isRestricted = () => true;
+    bindings.getAllowedStyles = () => [restrictedStyle];
+    const tool = findTool(
+      createGeneratorWebMcpTools(bindings),
+      "configure_generator"
+    );
+
+    await expect(
+      tool.execute({ backgroundColor: "#ffffff" }, createExecutionOptions())
+    ).rejects.toMatchObject({ code: "customization_not_allowed" });
+
+    const result = (await tool.execute(
+      { restrictedStyleName: "brand teal", iconSize: 256 },
+      createExecutionOptions()
+    )) as { applied: { restrictedStyleName: string } };
+
+    expect(actions.setBackgroundColor).toHaveBeenCalledWith("#17494d");
+    expect(actions.setIconColor).toHaveBeenCalledWith("#ffffff");
+    expect(result.applied.restrictedStyleName).toBe("Brand teal");
+  });
+
+  it("downloads a validated bundle using the selected preset", async () => {
+    const { bindings } = createBindings();
+    const tool = findTool(
+      createGeneratorWebMcpTools(bindings),
+      "export_icon_bundle"
+    );
+
+    const result = (await tool.execute(
+      { exportPresetId: zendeskPreset.id },
+      createExecutionOptions()
+    )) as { downloaded: boolean; filename: string; isZip: boolean };
+
+    expect(mocks.validateExport).toHaveBeenCalled();
+    expect(mocks.generateExportDownloadPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ selectedIconId: featherStar.id }),
+      [],
+      undefined,
+      { preset: zendeskPreset }
+    );
+    expect(mocks.downloadFile).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "zendesk-app-icons.zip"
+    );
+    expect(result).toEqual({
+      downloaded: true,
+      filename: "zendesk-app-icons.zip",
+      isZip: true,
+      apiVersion: "0.1.0",
+      filenames: ["logo.png"],
+      metadata: expect.any(Object),
+      warnings: [],
+    });
+  });
+});

--- a/src/utils/__tests__/webmcp.test.ts
+++ b/src/utils/__tests__/webmcp.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IconMetadata } from "../../types/icon";
+import {
+  createWebMcpTools,
+  registerWebMcpTools,
+  type WebMcpModelContext,
+  type WebMcpToolDefinition,
+} from "../webmcp";
+
+const featherStar: IconMetadata = {
+  id: "feather-star",
+  name: "Star",
+  pack: "feather",
+  svg: '<svg viewBox="0 0 24 24"><path d="M1 1" /></svg>',
+  keywords: ["star", "favorite"],
+};
+
+vi.mock("../icon-catalog", () => ({
+  getIconById: vi.fn(async (id: string) =>
+    id === featherStar.id ? featherStar : null
+  ),
+  searchIcons: vi.fn(async () => [featherStar]),
+  filterIconsByPack: vi.fn((icons: IconMetadata[], pack: string) =>
+    pack === "all" ? icons : icons.filter((icon) => icon.pack === pack)
+  ),
+}));
+
+vi.mock("../renderer", () => ({
+  renderSvg: vi.fn(() => '<svg viewBox="0 0 128 128"><path /></svg>'),
+}));
+
+function createExecutionOptions(): { signal: AbortSignal } {
+  return { signal: new AbortController().signal };
+}
+
+function findTool(tools: WebMcpToolDefinition[], name: string) {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error("Tool " + name + " was not created");
+  }
+  return tool;
+}
+
+describe("webmcp tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers the demo tools and can dispose them", async () => {
+    const registeredTools: WebMcpToolDefinition[] = [];
+    const registerTool = vi.fn(
+      async (
+        tool: WebMcpToolDefinition,
+        _options?: { signal?: AbortSignal }
+      ) => {
+        registeredTools.push(tool);
+      }
+    );
+    const modelContext: WebMcpModelContext = { registerTool };
+
+    const registration = await registerWebMcpTools(modelContext);
+
+    expect(registeredTools.map((tool) => tool.name)).toEqual([
+      "search_icons",
+      "get_icon",
+      "generate_icon_svg",
+    ]);
+    expect(registration.toolNames).toEqual([
+      "search_icons",
+      "get_icon",
+      "generate_icon_svg",
+    ]);
+
+    registration.dispose();
+    expect(registerTool.mock.calls[0][1]?.signal?.aborted).toBe(true);
+  });
+
+  it("returns compact search results without SVG source", async () => {
+    const tool = findTool(createWebMcpTools(), "search_icons");
+    const result = (await tool.execute(
+      { query: "star", limit: 5 },
+      createExecutionOptions()
+    )) as { icons: Array<Record<string, unknown>>; count: number };
+
+    expect(result.count).toBe(1);
+    expect(result.icons[0]).toMatchObject({
+      id: "feather-star",
+      name: "Star",
+      pack: "feather",
+    });
+    expect(result.icons[0]).not.toHaveProperty("svg");
+  });
+
+  it("generates an SVG using validated tool input", async () => {
+    const tool = findTool(createWebMcpTools(), "generate_icon_svg");
+    const result = (await tool.execute(
+      {
+        iconId: "feather-star",
+        backgroundColor: "#17494d",
+        iconColor: "#ffffff",
+        size: 128,
+      },
+      createExecutionOptions()
+    )) as { svg: string; settings: { outputSize: number } };
+
+    expect(result.svg).toContain("<svg");
+    expect(result.settings.outputSize).toBe(128);
+  });
+
+  it("returns stable errors for missing icons and invalid input", async () => {
+    const tools = createWebMcpTools();
+    const getIconTool = findTool(tools, "get_icon");
+    const generateTool = findTool(tools, "generate_icon_svg");
+
+    await expect(
+      getIconTool.execute({ iconId: "missing-icon" }, createExecutionOptions())
+    ).rejects.toMatchObject({ code: "icon_not_found" });
+
+    await expect(
+      generateTool.execute(
+        { iconId: "feather-star", iconColor: "not-a-color" },
+        createExecutionOptions()
+      )
+    ).rejects.toMatchObject({ code: "invalid_input" });
+  });
+});

--- a/src/utils/webmcp-generator.ts
+++ b/src/utils/webmcp-generator.ts
@@ -1,0 +1,879 @@
+import { z } from "zod";
+import { ICON_PACKS, type IconPack } from "../constants/app";
+import type { CanvasEditorState } from "../types/canvas";
+import { APP_LOCATIONS, type AppLocation } from "../types/app-location";
+import type { ExportPreset, StylePreset } from "../types/preset";
+import type { RestrictedStyle } from "../types/restriction";
+import type {
+  IconGeneratorActions,
+  IconGeneratorState,
+} from "../hooks/use-icon-generator";
+import type { BackgroundValue } from "./gradients";
+import {
+  downloadFile,
+  generateExportDownloadPayload,
+  validateExport,
+} from "./export-controller";
+import { getIconById } from "./icon-catalog";
+import {
+  createWebMcpTools,
+  toIconDetail,
+  toPublicIconMetadata,
+  WEBMCP_API_VERSION,
+  type WebMcpInputSchema,
+  type WebMcpToolDefinition,
+  WebMcpToolError,
+} from "./webmcp";
+import { renderSvg } from "./renderer";
+
+export const WEBMCP_GENERATOR_TOOL_NAMES = [
+  "inspect_generator_state",
+  "configure_generator",
+  "render_current_icon",
+  "export_icon_bundle",
+] as const;
+
+export type WebMcpGeneratorToolName =
+  (typeof WEBMCP_GENERATOR_TOOL_NAMES)[number];
+
+export interface WebMcpGeneratorBindings {
+  getState: () => IconGeneratorState;
+  getCanvasState: () => CanvasEditorState;
+  getExportPresets: () => ExportPreset[];
+  getSelectedExportPresetId: () => string;
+  getStylePresets: () => StylePreset[];
+  getSelectedStylePresetId: () => string | null;
+  isIconPackAllowed: (pack: IconPack) => boolean;
+  isExportPresetAllowed: (preset: ExportPreset) => boolean;
+  isRestricted: () => boolean;
+  getAllowedStyles: () => RestrictedStyle[];
+  actions: IconGeneratorActions;
+  selectExportPreset: (id: string) => void;
+  selectStylePreset: (id: string | null) => void;
+}
+
+interface ExportPresetSummary {
+  id: string;
+  name: string;
+  description: string;
+  isBuiltIn: boolean;
+  variants: Array<{
+    filename: string;
+    width: number;
+    height: number;
+    format: string;
+  }>;
+}
+
+interface StylePresetSummary {
+  id: string;
+  name: string;
+  isBuiltIn: boolean;
+}
+
+interface GeneratorStateSnapshot {
+  apiVersion: string;
+  selectedIconId: string | null;
+  selectedIcon: ReturnType<typeof toPublicIconMetadata> | null;
+  selectedPack: IconPack;
+  selectedLocations: AppLocation[];
+  customization: {
+    backgroundColor: BackgroundValue;
+    iconColor: string;
+    iconSize: number;
+    svgIconSize: number;
+    cornerRadius: number;
+    borderEnabled: boolean;
+    borderColor: string;
+    borderWidth: number;
+  };
+  selectedStylePresetId: string | null;
+  stylePresets: StylePresetSummary[];
+  restrictedStyles: Array<{ name: string }>;
+  selectedExportPresetId: string | null;
+  selectedExportPreset: ExportPresetSummary | null;
+  exportPresets: ExportPresetSummary[];
+  availableLocations: Array<{
+    value: AppLocation;
+    label: string;
+    description: string;
+  }>;
+}
+
+const hexColorSchema = z.string().regex(/^#[0-9a-fA-F]{6}$/, {
+  message: "Expected color in #RRGGBB format",
+});
+
+const gradientStopSchema = z.object({
+  color: hexColorSchema,
+  offset: z.number().min(0).max(100),
+});
+
+const backgroundSchema = z.union([
+  hexColorSchema,
+  z.object({
+    type: z.literal("linear"),
+    angle: z.number(),
+    stops: z.array(gradientStopSchema).min(2),
+  }),
+  z.object({
+    type: z.literal("radial"),
+    centerX: z.number().min(0).max(100),
+    centerY: z.number().min(0).max(100),
+    radius: z.number().min(0).max(100),
+    stops: z.array(gradientStopSchema).min(2),
+  }),
+]);
+
+const iconPackSchema = z.enum([
+  "all",
+  "garden",
+  "feather",
+  "remixicon",
+  "emoji",
+  "custom-svg",
+  "custom-image",
+  "canvas",
+]);
+
+const appLocationSchema = z.enum([
+  "all_locations",
+  "ticket_sidebar",
+  "new_ticket_sidebar",
+  "ticket_editor",
+  "user_sidebar",
+  "organization_sidebar",
+  "nav_bar",
+  "top_bar",
+  "background",
+  "modal",
+]);
+
+const emptyInputSchema: WebMcpInputSchema = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+};
+
+const configureGeneratorInputSchema = z
+  .object({
+    iconId: z.string().min(1).max(160).optional(),
+    pack: iconPackSchema.optional(),
+    locations: z.array(appLocationSchema).max(10).optional(),
+    stylePresetId: z.string().min(1).max(160).optional(),
+    restrictedStyleName: z.string().min(1).max(160).optional(),
+    backgroundColor: backgroundSchema.optional(),
+    iconColor: hexColorSchema.optional(),
+    iconSize: z.number().int().min(16).max(4096).optional(),
+    svgIconSize: z.number().int().min(16).max(4096).optional(),
+    cornerRadius: z.number().min(0).max(100).optional(),
+    borderEnabled: z.boolean().optional(),
+    borderColor: hexColorSchema.optional(),
+    borderWidth: z.number().min(0).max(64).optional(),
+    exportPresetId: z.string().min(1).max(160).optional(),
+  })
+  .strict()
+  .refine((input) => Object.keys(input).length > 0, {
+    message: "Provide at least one generator setting to change.",
+  });
+
+const configureGeneratorInputJsonSchema: WebMcpInputSchema = {
+  type: "object",
+  properties: {
+    iconId: {
+      type: "string",
+      minLength: 1,
+      maxLength: 160,
+      description: "The exact icon ID returned by search_icons.",
+    },
+    pack: {
+      type: "string",
+      enum: [
+        "all",
+        "garden",
+        "feather",
+        "remixicon",
+        "emoji",
+        "custom-svg",
+        "custom-image",
+        "canvas",
+      ],
+      description: "The icon pack shown in the generator.",
+    },
+    locations: {
+      type: "array",
+      maxItems: 10,
+      items: {
+        type: "string",
+        enum: [
+          "all_locations",
+          "ticket_sidebar",
+          "new_ticket_sidebar",
+          "ticket_editor",
+          "user_sidebar",
+          "organization_sidebar",
+          "nav_bar",
+          "top_bar",
+          "background",
+          "modal",
+        ],
+      },
+      description: "Zendesk app locations to include in an export.",
+    },
+    stylePresetId: {
+      type: "string",
+      description: "An existing style preset ID to apply before overrides.",
+    },
+    restrictedStyleName: {
+      type: "string",
+      description:
+        "Name of an allowed restricted-mode style. Use this instead of direct color or border settings when the page is restricted.",
+    },
+    backgroundColor: {
+      description: "A #RRGGBB color or a linear/radial gradient object.",
+      oneOf: [
+        { type: "string", pattern: "^#[0-9a-fA-F]{6}$" },
+        { type: "object" },
+      ],
+    },
+    iconColor: {
+      type: "string",
+      pattern: "^#[0-9a-fA-F]{6}$",
+      description: "The icon color in #RRGGBB format.",
+    },
+    iconSize: {
+      type: "integer",
+      minimum: 16,
+      maximum: 4096,
+      description: "PNG artboard size.",
+    },
+    svgIconSize: {
+      type: "integer",
+      minimum: 16,
+      maximum: 4096,
+      description: "SVG artboard size.",
+    },
+    cornerRadius: {
+      type: "number",
+      minimum: 0,
+      maximum: 100,
+      description: "Background corner radius as a percentage.",
+    },
+    borderEnabled: {
+      type: "boolean",
+      description: "Whether to draw a border around the background.",
+    },
+    borderColor: {
+      type: "string",
+      pattern: "^#[0-9a-fA-F]{6}$",
+      description: "The border color in #RRGGBB format.",
+    },
+    borderWidth: {
+      type: "number",
+      minimum: 0,
+      maximum: 64,
+      description: "The border width in normalized artboard units.",
+    },
+    exportPresetId: {
+      type: "string",
+      description: "An export preset ID to select for future exports.",
+    },
+  },
+  additionalProperties: false,
+};
+
+const exportIconBundleInputSchema = z
+  .object({
+    exportPresetId: z.string().min(1).max(160).optional(),
+    locations: z.array(appLocationSchema).max(10).optional(),
+  })
+  .strict();
+
+const exportIconBundleInputJsonSchema: WebMcpInputSchema = {
+  type: "object",
+  properties: {
+    exportPresetId: {
+      type: "string",
+      description:
+        "Optional export preset ID; defaults to the selected preset.",
+    },
+    locations: configureGeneratorInputJsonSchema.properties.locations,
+  },
+  additionalProperties: false,
+};
+
+function parseToolInput<T>(schema: z.ZodType<T>, inputObject: unknown): T {
+  const result = schema.safeParse(inputObject);
+  if (!result.success) {
+    throw new WebMcpToolError(
+      "invalid_input",
+      "The tool input did not match the expected schema.",
+      result.error.flatten()
+    );
+  }
+  return result.data;
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    const error = new Error("The tool execution was cancelled.");
+    error.name = "AbortError";
+    throw error;
+  }
+}
+
+function waitForStateCommit(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function iconNotFound(iconId: string): WebMcpToolError {
+  return new WebMcpToolError(
+    "icon_not_found",
+    "Icon '" + iconId + "' was not found in the current catalog."
+  );
+}
+
+function toUiIconPack(pack: string): IconPack {
+  if (pack === "zendesk-garden") return ICON_PACKS.GARDEN;
+  if (pack === "feather") return ICON_PACKS.FEATHER;
+  if (pack === "remixicon") return ICON_PACKS.REMIXICON;
+  if (pack === "emoji") return ICON_PACKS.EMOJI;
+  if (pack === "custom-svg") return ICON_PACKS.CUSTOM_SVG;
+  if (pack === "custom-image") return ICON_PACKS.CUSTOM_IMAGE;
+  return ICON_PACKS.ALL;
+}
+
+function normalizeLocations(locations: AppLocation[]): AppLocation[] {
+  const uniqueLocations = [...new Set(locations)];
+  return uniqueLocations.includes("all_locations")
+    ? ["all_locations"]
+    : uniqueLocations;
+}
+
+function toExportPresetSummary(preset: ExportPreset): ExportPresetSummary {
+  return {
+    id: preset.id,
+    name: preset.name,
+    description: preset.description,
+    isBuiltIn: preset.isBuiltIn,
+    variants: preset.variants.map((variant) => ({
+      filename: variant.filename,
+      width: variant.width,
+      height: variant.height,
+      format: variant.format,
+    })),
+  };
+}
+
+function toStylePresetSummary(preset: StylePreset): StylePresetSummary {
+  return {
+    id: preset.id,
+    name: preset.name,
+    isBuiltIn: preset.isBuiltIn,
+  };
+}
+
+function getExportPreset(
+  bindings: WebMcpGeneratorBindings,
+  requestedId?: string
+): ExportPreset | null {
+  const presets = bindings.getExportPresets();
+  const selectedId = requestedId ?? bindings.getSelectedExportPresetId();
+  return (
+    presets.find((preset) => preset.id === selectedId) ??
+    (requestedId ? null : (presets[0] ?? null))
+  );
+}
+
+async function getGeneratorStateSnapshot(
+  bindings: WebMcpGeneratorBindings
+): Promise<GeneratorStateSnapshot> {
+  const state = bindings.getState();
+  const selectedIcon = state.selectedIconId
+    ? await getIconById(state.selectedIconId)
+    : null;
+  const presets = bindings.getExportPresets();
+  const selectedExportPreset = getExportPreset(bindings);
+  const stylePresets = bindings.getStylePresets();
+  const restrictedStyles = bindings.getAllowedStyles();
+
+  return {
+    apiVersion: WEBMCP_API_VERSION,
+    selectedIconId: state.selectedIconId ?? null,
+    selectedIcon: selectedIcon ? toPublicIconMetadata(selectedIcon) : null,
+    selectedPack: state.selectedPack,
+    selectedLocations: state.selectedLocations,
+    customization: {
+      backgroundColor: state.backgroundColor,
+      iconColor: state.iconColor,
+      iconSize: state.iconSize,
+      svgIconSize: state.svgIconSize,
+      cornerRadius: state.cornerRadius,
+      borderEnabled: state.borderEnabled,
+      borderColor: state.borderColor,
+      borderWidth: state.borderWidth,
+    },
+    selectedStylePresetId: bindings.getSelectedStylePresetId(),
+    stylePresets: stylePresets.map(toStylePresetSummary),
+    restrictedStyles: restrictedStyles.map(({ name }) => ({ name })),
+    selectedExportPresetId: selectedExportPreset?.id ?? null,
+    selectedExportPreset: selectedExportPreset
+      ? toExportPresetSummary(selectedExportPreset)
+      : null,
+    exportPresets: presets.map(toExportPresetSummary),
+    availableLocations: APP_LOCATIONS.map(({ value, label, description }) => ({
+      value,
+      label,
+      description,
+    })),
+  };
+}
+
+function getCurrentSvgSettings(state: IconGeneratorState) {
+  return {
+    backgroundColor: state.backgroundColor,
+    iconColor: state.iconColor,
+    size: state.svgIconSize,
+    outputSize: state.svgIconSize,
+    cornerRadius: state.cornerRadius,
+    borderEnabled: state.borderEnabled,
+    borderColor: state.borderColor,
+    borderWidth: state.borderWidth,
+  };
+}
+
+export function createGeneratorWebMcpTools(
+  bindings: WebMcpGeneratorBindings
+): WebMcpToolDefinition[] {
+  const baseTools = createWebMcpTools();
+
+  const generatorTools: WebMcpToolDefinition[] = [
+    {
+      name: "inspect_generator_state",
+      title: "Inspect generator state",
+      description:
+        "Read the current icon, customization, selected locations, available style choices, and export presets.",
+      inputSchema: emptyInputSchema,
+      annotations: { readOnlyHint: true },
+      execute: async (_inputObject, options) => {
+        throwIfAborted(options.signal);
+        const snapshot = await getGeneratorStateSnapshot(bindings);
+        throwIfAborted(options.signal);
+        return snapshot;
+      },
+    },
+    {
+      name: "configure_generator",
+      title: "Configure icon generator",
+      description:
+        "Select an icon and apply customization, location, style preset, and export preset choices to the visible generator.",
+      inputSchema: configureGeneratorInputJsonSchema,
+      annotations: { readOnlyHint: false },
+      execute: async (inputObject, options) => {
+        throwIfAborted(options.signal);
+        const input = parseToolInput(
+          configureGeneratorInputSchema,
+          inputObject
+        );
+        const currentState = bindings.getState();
+        const isRestricted = bindings.isRestricted();
+        const stylePreset = input.stylePresetId
+          ? bindings
+              .getStylePresets()
+              .find((preset) => preset.id === input.stylePresetId)
+          : undefined;
+
+        if (input.restrictedStyleName && !isRestricted) {
+          throw new WebMcpToolError(
+            "restricted_style_not_available",
+            "Restricted styles are only available when the page is in restricted mode."
+          );
+        }
+
+        if (input.stylePresetId && isRestricted) {
+          throw new WebMcpToolError(
+            "style_preset_not_allowed",
+            "Style presets are unavailable in restricted mode. Use restrictedStyleName with a name from inspect_generator_state."
+          );
+        }
+
+        if (input.stylePresetId && !stylePreset) {
+          throw new WebMcpToolError(
+            "style_preset_not_found",
+            "Style preset '" + input.stylePresetId + "' was not found."
+          );
+        }
+
+        const restrictedStyle = input.restrictedStyleName
+          ? bindings
+              .getAllowedStyles()
+              .find(
+                (style) =>
+                  style.name.toLowerCase() ===
+                  input.restrictedStyleName?.toLowerCase()
+              )
+          : undefined;
+
+        if (input.restrictedStyleName && !restrictedStyle) {
+          throw new WebMcpToolError(
+            "restricted_style_not_found",
+            "Restricted style '" +
+              input.restrictedStyleName +
+              "' was not found in the allowed styles."
+          );
+        }
+
+        const directCustomizationKeys = [
+          "backgroundColor",
+          "iconColor",
+          "cornerRadius",
+          "borderEnabled",
+          "borderColor",
+          "borderWidth",
+        ] as const;
+        if (
+          isRestricted &&
+          directCustomizationKeys.some((key) => input[key] !== undefined)
+        ) {
+          throw new WebMcpToolError(
+            "customization_not_allowed",
+            "Direct color and border customization is unavailable in restricted mode. Use restrictedStyleName with a name from inspect_generator_state."
+          );
+        }
+
+        if (input.pack && !bindings.isIconPackAllowed(input.pack)) {
+          throw new WebMcpToolError(
+            "icon_pack_not_allowed",
+            "The requested icon pack is not available in the current app configuration."
+          );
+        }
+
+        let selectedIcon = null;
+        if (input.iconId) {
+          selectedIcon = await getIconById(input.iconId);
+          if (!selectedIcon) {
+            throw iconNotFound(input.iconId);
+          }
+
+          if (!bindings.isIconPackAllowed(toUiIconPack(selectedIcon.pack))) {
+            throw new WebMcpToolError(
+              "icon_pack_not_allowed",
+              "The requested icon belongs to a pack that is not available in the current app configuration."
+            );
+          }
+        }
+
+        const selectedExportPreset = input.exportPresetId
+          ? getExportPreset(bindings, input.exportPresetId)
+          : undefined;
+        if (input.exportPresetId && !selectedExportPreset) {
+          throw new WebMcpToolError(
+            "export_preset_not_found",
+            "Export preset '" + input.exportPresetId + "' was not found."
+          );
+        }
+        if (
+          selectedExportPreset &&
+          !bindings.isExportPresetAllowed(selectedExportPreset)
+        ) {
+          throw new WebMcpToolError(
+            "export_preset_not_allowed",
+            "The requested export preset is not available in the current app configuration."
+          );
+        }
+
+        const styleValues = stylePreset
+          ? {
+              backgroundColor: stylePreset.backgroundColor,
+              iconColor: stylePreset.iconColor,
+              cornerRadius: stylePreset.cornerRadius,
+              borderEnabled: stylePreset.borderEnabled,
+              borderColor: stylePreset.borderColor,
+              borderWidth: stylePreset.borderWidth,
+            }
+          : {};
+        const restrictedStyleValues = restrictedStyle
+          ? {
+              backgroundColor: restrictedStyle.backgroundColor,
+              iconColor: restrictedStyle.iconColor,
+            }
+          : {};
+        const nextState = {
+          ...currentState,
+          ...styleValues,
+          ...restrictedStyleValues,
+          ...(input.backgroundColor === undefined
+            ? {}
+            : { backgroundColor: input.backgroundColor }),
+          ...(input.iconColor === undefined
+            ? {}
+            : { iconColor: input.iconColor }),
+          ...(input.iconSize === undefined ? {} : { iconSize: input.iconSize }),
+          ...(input.svgIconSize === undefined
+            ? {}
+            : { svgIconSize: input.svgIconSize }),
+          ...(input.cornerRadius === undefined
+            ? {}
+            : { cornerRadius: input.cornerRadius }),
+          ...(input.borderEnabled === undefined
+            ? {}
+            : { borderEnabled: input.borderEnabled }),
+          ...(input.borderColor === undefined
+            ? {}
+            : { borderColor: input.borderColor }),
+          ...(input.borderWidth === undefined
+            ? {}
+            : { borderWidth: input.borderWidth }),
+          ...(input.locations === undefined
+            ? {}
+            : { selectedLocations: normalizeLocations(input.locations) }),
+          ...(input.iconId === undefined
+            ? {}
+            : { selectedIconId: input.iconId }),
+          ...(input.pack === undefined ? {} : { selectedPack: input.pack }),
+        };
+
+        if (stylePreset) {
+          bindings.selectStylePreset(stylePreset.id);
+        }
+        if (restrictedStyle) {
+          bindings.selectStylePreset(null);
+          bindings.actions.setBackgroundColor(restrictedStyle.backgroundColor);
+          bindings.actions.setIconColor(restrictedStyle.iconColor);
+        }
+        if (input.iconId) {
+          bindings.actions.setSelectedIconId(input.iconId);
+        }
+        if (input.pack) {
+          bindings.actions.setSelectedPack(input.pack);
+        }
+        if (input.locations) {
+          bindings.actions.setSelectedLocations(
+            normalizeLocations(input.locations)
+          );
+        }
+        if (input.backgroundColor !== undefined) {
+          bindings.actions.setBackgroundColor(input.backgroundColor);
+        }
+        if (input.iconColor !== undefined) {
+          bindings.actions.setIconColor(input.iconColor);
+        }
+        if (input.iconSize !== undefined) {
+          bindings.actions.setIconSize(input.iconSize);
+        }
+        if (input.svgIconSize !== undefined) {
+          bindings.actions.setSvgIconSize(input.svgIconSize);
+        }
+        if (input.cornerRadius !== undefined) {
+          bindings.actions.setCornerRadius(input.cornerRadius);
+        }
+        if (input.borderEnabled !== undefined) {
+          bindings.actions.setBorderEnabled(input.borderEnabled);
+        }
+        if (input.borderColor !== undefined) {
+          bindings.actions.setBorderColor(input.borderColor);
+        }
+        if (input.borderWidth !== undefined) {
+          bindings.actions.setBorderWidth(input.borderWidth);
+        }
+        if (stylePreset) {
+          bindings.actions.setBackgroundColor(stylePreset.backgroundColor);
+          bindings.actions.setIconColor(stylePreset.iconColor);
+          bindings.actions.setCornerRadius(stylePreset.cornerRadius);
+          bindings.actions.setBorderEnabled(stylePreset.borderEnabled);
+          bindings.actions.setBorderColor(stylePreset.borderColor);
+          bindings.actions.setBorderWidth(stylePreset.borderWidth);
+          if (input.backgroundColor !== undefined) {
+            bindings.actions.setBackgroundColor(input.backgroundColor);
+          }
+          if (input.iconColor !== undefined) {
+            bindings.actions.setIconColor(input.iconColor);
+          }
+          if (input.cornerRadius !== undefined) {
+            bindings.actions.setCornerRadius(input.cornerRadius);
+          }
+          if (input.borderEnabled !== undefined) {
+            bindings.actions.setBorderEnabled(input.borderEnabled);
+          }
+          if (input.borderColor !== undefined) {
+            bindings.actions.setBorderColor(input.borderColor);
+          }
+          if (input.borderWidth !== undefined) {
+            bindings.actions.setBorderWidth(input.borderWidth);
+          }
+        }
+        if (selectedExportPreset) {
+          bindings.selectExportPreset(selectedExportPreset.id);
+        }
+
+        await waitForStateCommit();
+        throwIfAborted(options.signal);
+
+        const projectedBindings: WebMcpGeneratorBindings = {
+          ...bindings,
+          getState: () => nextState,
+          getSelectedExportPresetId: () =>
+            selectedExportPreset?.id ?? bindings.getSelectedExportPresetId(),
+          getSelectedStylePresetId: () =>
+            restrictedStyle
+              ? null
+              : (stylePreset?.id ?? bindings.getSelectedStylePresetId()),
+        };
+
+        return {
+          apiVersion: WEBMCP_API_VERSION,
+          applied: {
+            iconId: selectedIcon?.id ?? input.iconId ?? null,
+            pack: input.pack ?? null,
+            locations:
+              input.locations === undefined
+                ? null
+                : normalizeLocations(input.locations),
+            stylePresetId: stylePreset?.id ?? null,
+            restrictedStyleName: restrictedStyle?.name ?? null,
+            exportPresetId: selectedExportPreset?.id ?? null,
+            customization: {
+              backgroundColor:
+                input.backgroundColor ??
+                styleValues.backgroundColor ??
+                restrictedStyleValues.backgroundColor ??
+                null,
+              iconColor:
+                input.iconColor ??
+                styleValues.iconColor ??
+                restrictedStyleValues.iconColor ??
+                null,
+              iconSize: input.iconSize ?? null,
+              svgIconSize: input.svgIconSize ?? null,
+              cornerRadius:
+                input.cornerRadius ?? styleValues.cornerRadius ?? null,
+              borderEnabled:
+                input.borderEnabled ?? styleValues.borderEnabled ?? null,
+              borderColor: input.borderColor ?? styleValues.borderColor ?? null,
+              borderWidth: input.borderWidth ?? styleValues.borderWidth ?? null,
+            },
+          },
+          state: await getGeneratorStateSnapshot(projectedBindings),
+        };
+      },
+    },
+    {
+      name: "render_current_icon",
+      title: "Render current icon",
+      description:
+        "Render the selected icon using the visible generator customization without downloading or changing the page.",
+      inputSchema: emptyInputSchema,
+      annotations: { readOnlyHint: true, untrustedContentHint: true },
+      execute: async (_inputObject, options) => {
+        throwIfAborted(options.signal);
+        const state = bindings.getState();
+        if (!state.selectedIconId) {
+          throw new WebMcpToolError(
+            "no_icon_selected",
+            "Select an icon before rendering the current configuration."
+          );
+        }
+        const icon = await getIconById(state.selectedIconId);
+        throwIfAborted(options.signal);
+        if (!icon) {
+          throw iconNotFound(state.selectedIconId);
+        }
+        if (!icon.svg) {
+          throw new WebMcpToolError(
+            "svg_not_available",
+            "The selected icon does not have SVG source available."
+          );
+        }
+
+        const settings = getCurrentSvgSettings(state);
+        return {
+          apiVersion: WEBMCP_API_VERSION,
+          icon: toIconDetail(icon),
+          settings,
+          svg: renderSvg({
+            icon,
+            backgroundColor: settings.backgroundColor,
+            iconColor: settings.iconColor,
+            size: settings.size,
+            outputSize: settings.outputSize,
+            cornerRadius: settings.cornerRadius,
+            borderEnabled: settings.borderEnabled,
+            borderColor: settings.borderColor,
+            borderWidth: settings.borderWidth,
+          }),
+        };
+      },
+    },
+    {
+      name: "export_icon_bundle",
+      title: "Export icon bundle",
+      description:
+        "Generate and download the configured icon bundle using the selected export preset and locations. This starts a browser download.",
+      inputSchema: exportIconBundleInputJsonSchema,
+      annotations: { readOnlyHint: false, untrustedContentHint: true },
+      execute: async (inputObject, options) => {
+        throwIfAborted(options.signal);
+        const input = parseToolInput(exportIconBundleInputSchema, inputObject);
+        const currentState = bindings.getState();
+        const selectedLocations = input.locations
+          ? normalizeLocations(input.locations)
+          : currentState.selectedLocations;
+        const preset = getExportPreset(bindings, input.exportPresetId);
+
+        if (input.exportPresetId && !preset) {
+          throw new WebMcpToolError(
+            "export_preset_not_found",
+            "Export preset '" + input.exportPresetId + "' was not found."
+          );
+        }
+        if (preset && !bindings.isExportPresetAllowed(preset)) {
+          throw new WebMcpToolError(
+            "export_preset_not_allowed",
+            "The requested export preset is not available in the current app configuration."
+          );
+        }
+
+        if (input.locations) {
+          bindings.actions.setSelectedLocations(selectedLocations);
+        }
+        if (preset && preset.id !== bindings.getSelectedExportPresetId()) {
+          bindings.selectExportPreset(preset.id);
+        }
+
+        const validation = validateExport(currentState, selectedLocations);
+        if (!validation.valid) {
+          throw new WebMcpToolError(
+            "export_invalid",
+            "The current generator configuration cannot be exported.",
+            validation
+          );
+        }
+
+        const payload = await generateExportDownloadPayload(
+          input.locations
+            ? { ...currentState, selectedLocations }
+            : currentState,
+          selectedLocations,
+          currentState.selectedPack === ICON_PACKS.CANVAS
+            ? bindings.getCanvasState()
+            : undefined,
+          preset ? { preset } : undefined
+        );
+        throwIfAborted(options.signal);
+        downloadFile(payload.blob, payload.filename);
+
+        return {
+          apiVersion: WEBMCP_API_VERSION,
+          downloaded: true,
+          filename: payload.filename,
+          isZip: payload.isZip,
+          filenames: payload.filenames,
+          metadata: payload.metadata,
+          warnings: validation.warnings,
+        };
+      },
+    },
+  ];
+
+  return [...baseTools, ...generatorTools];
+}

--- a/src/utils/webmcp.ts
+++ b/src/utils/webmcp.ts
@@ -1,0 +1,441 @@
+import { z } from "zod";
+import { filterIconsByPack, getIconById, searchIcons } from "./icon-catalog";
+import { renderSvg } from "./renderer";
+import type { IconMetadata } from "../types/icon";
+
+export const WEBMCP_API_VERSION = "0.1.0";
+
+export const WEBMCP_TOOL_NAMES = [
+  "search_icons",
+  "get_icon",
+  "generate_icon_svg",
+] as const;
+
+export type WebMcpToolName = (typeof WEBMCP_TOOL_NAMES)[number];
+
+export interface WebMcpInputSchema {
+  type: "object";
+  properties: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+export interface WebMcpToolAnnotations {
+  readOnlyHint?: boolean;
+  untrustedContentHint?: boolean;
+}
+
+export interface WebMcpToolExecuteOptions {
+  signal: AbortSignal;
+}
+
+export interface WebMcpToolDefinition {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: WebMcpInputSchema;
+  annotations?: WebMcpToolAnnotations;
+  execute: (
+    inputObject: Record<string, unknown>,
+    options: WebMcpToolExecuteOptions
+  ) => Promise<unknown>;
+}
+
+export interface WebMcpModelContext {
+  registerTool(
+    tool: WebMcpToolDefinition,
+    options?: { signal?: AbortSignal }
+  ): Promise<void>;
+}
+
+interface DocumentWithModelContext extends Document {
+  modelContext?: WebMcpModelContext;
+}
+
+export interface WebMcpRegistration {
+  toolNames: WebMcpToolName[];
+  dispose: () => void;
+}
+
+export interface PublicIconMetadata {
+  id: string;
+  name: string;
+  pack: IconMetadata["pack"];
+  variant?: string;
+  category?: string;
+  size?: number;
+  isRasterized: boolean;
+}
+
+export interface IconDetail extends PublicIconMetadata {
+  svg: string;
+}
+
+export interface GeneratedIconSvgResult {
+  apiVersion: string;
+  icon: IconDetail;
+  settings: {
+    backgroundColor: string | Record<string, unknown>;
+    iconColor: string;
+    size: number;
+    padding: number;
+    outputSize: number;
+    cornerRadius: number;
+    borderEnabled: boolean;
+    borderColor: string;
+    borderWidth: number;
+  };
+  svg: string;
+}
+
+export class WebMcpToolError extends Error {
+  readonly code: string;
+  readonly details?: unknown;
+
+  constructor(code: string, message: string, details?: unknown) {
+    super(message);
+    this.name = "WebMcpToolError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+const hexColorSchema = z.string().regex(/^#[0-9a-fA-F]{6}$/, {
+  message: "Expected color in #RRGGBB format",
+});
+
+const gradientStopSchema = z.object({
+  color: hexColorSchema,
+  offset: z.number().min(0).max(100),
+});
+
+const backgroundSchema = z.union([
+  hexColorSchema,
+  z.object({
+    type: z.literal("linear"),
+    angle: z.number(),
+    stops: z.array(gradientStopSchema).min(2),
+  }),
+  z.object({
+    type: z.literal("radial"),
+    centerX: z.number().min(0).max(100),
+    centerY: z.number().min(0).max(100),
+    radius: z.number().min(0).max(100),
+    stops: z.array(gradientStopSchema).min(2),
+  }),
+]);
+
+const searchIconsInputSchema = z.object({
+  query: z.string().max(120).default(""),
+  pack: z
+    .enum([
+      "all",
+      "zendesk-garden",
+      "feather",
+      "remixicon",
+      "emoji",
+      "custom-svg",
+      "custom-image",
+    ])
+    .default("all"),
+  limit: z.number().int().min(1).max(25).default(10),
+});
+
+const getIconInputSchema = z.object({
+  iconId: z.string().min(1).max(160),
+});
+
+const generateIconSvgInputSchema = z.object({
+  iconId: z.string().min(1).max(160),
+  backgroundColor: backgroundSchema.default("#063940"),
+  iconColor: hexColorSchema.default("#ffffff"),
+  size: z.number().int().min(48).max(300).default(128),
+  padding: z.number().min(-200).max(200).default(8),
+  outputSize: z.number().int().min(16).max(4096).optional(),
+  cornerRadius: z.number().min(0).max(100).default(0),
+  borderEnabled: z.boolean().default(false),
+  borderColor: hexColorSchema.default("#ffffff"),
+  borderWidth: z.number().min(0).max(64).default(6),
+});
+
+const searchIconsInputJsonSchema: WebMcpInputSchema = {
+  type: "object",
+  properties: {
+    query: {
+      type: "string",
+      description:
+        "Text to match against icon names, IDs, keywords, and categories.",
+    },
+    pack: {
+      type: "string",
+      enum: [
+        "all",
+        "zendesk-garden",
+        "feather",
+        "remixicon",
+        "emoji",
+        "custom-svg",
+        "custom-image",
+      ],
+      description: "Optional icon pack filter.",
+    },
+    limit: {
+      type: "integer",
+      minimum: 1,
+      maximum: 25,
+      description: "Maximum number of results to return.",
+    },
+  },
+  additionalProperties: false,
+};
+
+const getIconInputJsonSchema: WebMcpInputSchema = {
+  type: "object",
+  properties: {
+    iconId: {
+      type: "string",
+      minLength: 1,
+      maxLength: 160,
+      description: "The exact icon ID returned by search_icons.",
+    },
+  },
+  required: ["iconId"],
+  additionalProperties: false,
+};
+
+const generateIconSvgInputJsonSchema: WebMcpInputSchema = {
+  type: "object",
+  properties: {
+    iconId: {
+      type: "string",
+      minLength: 1,
+      maxLength: 160,
+      description: "The exact icon ID returned by search_icons.",
+    },
+    backgroundColor: {
+      description: "A #RRGGBB color or a linear/radial gradient object.",
+      oneOf: [
+        { type: "string", pattern: "^#[0-9a-fA-F]{6}$" },
+        { type: "object" },
+      ],
+    },
+    iconColor: {
+      type: "string",
+      pattern: "^#[0-9a-fA-F]{6}$",
+      description: "The icon color in #RRGGBB format.",
+    },
+    size: {
+      type: "integer",
+      minimum: 48,
+      maximum: 300,
+      description: "The SVG artboard size.",
+    },
+    padding: {
+      type: "number",
+      minimum: -200,
+      maximum: 200,
+      description: "Padding around the icon in artboard units.",
+    },
+    outputSize: {
+      type: "integer",
+      minimum: 16,
+      maximum: 4096,
+      description: "Optional rendered width and height.",
+    },
+    cornerRadius: {
+      type: "number",
+      minimum: 0,
+      maximum: 100,
+      description: "Background corner radius as a percentage.",
+    },
+    borderEnabled: {
+      type: "boolean",
+      description: "Whether to draw a border around the background.",
+    },
+    borderColor: {
+      type: "string",
+      pattern: "^#[0-9a-fA-F]{6}$",
+      description: "The border color in #RRGGBB format.",
+    },
+    borderWidth: {
+      type: "number",
+      minimum: 0,
+      maximum: 64,
+      description: "The border width in normalized artboard units.",
+    },
+  },
+  required: ["iconId"],
+  additionalProperties: false,
+};
+
+function toPublicIconMetadata(icon: IconMetadata): PublicIconMetadata {
+  return {
+    id: icon.id,
+    name: icon.name,
+    pack: icon.pack,
+    variant: icon.variant,
+    category: icon.category,
+    size: icon.size,
+    isRasterized: icon.isRasterized ?? false,
+  };
+}
+
+function toIconDetail(icon: IconMetadata): IconDetail {
+  return {
+    ...toPublicIconMetadata(icon),
+    svg: icon.svg,
+  };
+}
+
+function parseToolInput<T>(schema: z.ZodType<T>, inputObject: unknown): T {
+  const result = schema.safeParse(inputObject);
+  if (!result.success) {
+    throw new WebMcpToolError(
+      "invalid_input",
+      "The tool input did not match the expected schema.",
+      result.error.flatten()
+    );
+  }
+  return result.data;
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    const error = new Error("The tool execution was cancelled.");
+    error.name = "AbortError";
+    throw error;
+  }
+}
+
+function iconNotFound(iconId: string): WebMcpToolError {
+  return new WebMcpToolError(
+    "icon_not_found",
+    "Icon '" + iconId + "' was not found in the current catalog."
+  );
+}
+
+export function createWebMcpTools(): WebMcpToolDefinition[] {
+  return [
+    {
+      name: "search_icons",
+      title: "Search icons",
+      description:
+        "Find bundled icons by name, ID, keyword, category, or icon pack.",
+      inputSchema: searchIconsInputJsonSchema,
+      annotations: { readOnlyHint: true },
+      execute: async (inputObject, options) => {
+        throwIfAborted(options.signal);
+        const input = parseToolInput(searchIconsInputSchema, inputObject);
+        const icons = await searchIcons(input.query);
+        throwIfAborted(options.signal);
+        const filteredIcons = await filterIconsByPack(icons, input.pack);
+
+        return {
+          apiVersion: WEBMCP_API_VERSION,
+          query: input.query,
+          pack: input.pack,
+          count: filteredIcons.length,
+          icons: filteredIcons.slice(0, input.limit).map(toPublicIconMetadata),
+        };
+      },
+    },
+    {
+      name: "get_icon",
+      title: "Get icon source",
+      description: "Read metadata and SVG source for one bundled icon.",
+      inputSchema: getIconInputJsonSchema,
+      annotations: { readOnlyHint: true, untrustedContentHint: true },
+      execute: async (inputObject, options) => {
+        throwIfAborted(options.signal);
+        const input = parseToolInput(getIconInputSchema, inputObject);
+        const icon = await getIconById(input.iconId);
+        throwIfAborted(options.signal);
+        if (!icon) {
+          throw iconNotFound(input.iconId);
+        }
+
+        return {
+          apiVersion: WEBMCP_API_VERSION,
+          icon: toIconDetail(icon),
+        };
+      },
+    },
+    {
+      name: "generate_icon_svg",
+      title: "Generate icon SVG",
+      description:
+        "Generate a customized SVG from a bundled icon without changing the page or downloading a file.",
+      inputSchema: generateIconSvgInputJsonSchema,
+      annotations: { readOnlyHint: true, untrustedContentHint: true },
+      execute: async (inputObject, options) => {
+        throwIfAborted(options.signal);
+        const input = parseToolInput(generateIconSvgInputSchema, inputObject);
+        const icon = await getIconById(input.iconId);
+        throwIfAborted(options.signal);
+        if (!icon) {
+          throw iconNotFound(input.iconId);
+        }
+
+        const settings = {
+          ...input,
+          outputSize: input.outputSize ?? input.size,
+        };
+        const svg = renderSvg({
+          icon,
+          backgroundColor: input.backgroundColor,
+          iconColor: input.iconColor,
+          size: input.size,
+          padding: input.padding,
+          outputSize: input.outputSize,
+          cornerRadius: input.cornerRadius,
+          borderEnabled: input.borderEnabled,
+          borderColor: input.borderColor,
+          borderWidth: input.borderWidth,
+        });
+
+        return {
+          apiVersion: WEBMCP_API_VERSION,
+          icon: toIconDetail(icon),
+          settings,
+          svg,
+        } satisfies GeneratedIconSvgResult;
+      },
+    },
+  ];
+}
+
+export function getDocumentModelContext(): WebMcpModelContext | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const modelContext = (document as DocumentWithModelContext).modelContext;
+  if (!modelContext || typeof modelContext.registerTool !== "function") {
+    return null;
+  }
+
+  return modelContext;
+}
+
+export async function registerWebMcpTools(
+  modelContext: WebMcpModelContext
+): Promise<WebMcpRegistration> {
+  const controller = new AbortController();
+  const tools = createWebMcpTools();
+
+  try {
+    await Promise.all(
+      tools.map((tool) =>
+        modelContext.registerTool(tool, { signal: controller.signal })
+      )
+    );
+  } catch (error) {
+    controller.abort();
+    throw error;
+  }
+
+  return {
+    toolNames: [...WEBMCP_TOOL_NAMES],
+    dispose: () => controller.abort(),
+  };
+}

--- a/src/utils/webmcp.ts
+++ b/src/utils/webmcp.ts
@@ -53,7 +53,7 @@ interface DocumentWithModelContext extends Document {
 }
 
 export interface WebMcpRegistration {
-  toolNames: WebMcpToolName[];
+  toolNames: string[];
   dispose: () => void;
 }
 
@@ -268,7 +268,7 @@ const generateIconSvgInputJsonSchema: WebMcpInputSchema = {
   additionalProperties: false,
 };
 
-function toPublicIconMetadata(icon: IconMetadata): PublicIconMetadata {
+export function toPublicIconMetadata(icon: IconMetadata): PublicIconMetadata {
   return {
     id: icon.id,
     name: icon.name,
@@ -280,7 +280,7 @@ function toPublicIconMetadata(icon: IconMetadata): PublicIconMetadata {
   };
 }
 
-function toIconDetail(icon: IconMetadata): IconDetail {
+export function toIconDetail(icon: IconMetadata): IconDetail {
   return {
     ...toPublicIconMetadata(icon),
     svg: icon.svg,
@@ -418,10 +418,10 @@ export function getDocumentModelContext(): WebMcpModelContext | null {
 }
 
 export async function registerWebMcpTools(
-  modelContext: WebMcpModelContext
+  modelContext: WebMcpModelContext,
+  tools: WebMcpToolDefinition[] = createWebMcpTools()
 ): Promise<WebMcpRegistration> {
   const controller = new AbortController();
-  const tools = createWebMcpTools();
 
   try {
     await Promise.all(
@@ -435,7 +435,7 @@ export async function registerWebMcpTools(
   }
 
   return {
-    toolNames: [...WEBMCP_TOOL_NAMES],
+    toolNames: tools.map((tool) => tool.name),
     dispose: () => controller.abort(),
   };
 }


### PR DESCRIPTION
## Summary

- keep `/webmcp` as a small test bench for the read-only API
- expose the complete stateful workflow from the main generator page
- reuse the visible React actions, preset data, renderer, export validation, and ZIP download path
- register seven top-level WebMCP tools when `document.modelContext` is available:
  - `search_icons`
  - `get_icon`
  - `generate_icon_svg`
  - `inspect_generator_state`
  - `configure_generator`
  - `render_current_icon`
  - `export_icon_bundle`
- return structured state, style choices, export preset metadata, SVG previews, filenames, and export metadata
- distinguish read-only inspection/rendering from the download-triggering export action
- preserve restricted-mode rules: arbitrary colors/borders are rejected and only allowed named styles can be selected
- document the JS API/WebMCP boundary and the ChatGPT testing flow

Closes #71

## Validation

- focused WebMCP tests: 9 passing
- production build: passing
- lint: passing
- formatting: passing
- authenticated in-app browser smoke: deployed main page displayed `Agent ready · 7 tools`
- Vercel preview build: Ready
- full unit suite: 470 passing, 2 unrelated failures caused by pre-existing unstaged changes in the working tree
- Playwright suite could not launch because the repository expects the missing `chromium_headless_shell-1200` binary; the test coverage is included in `e2e/webmcp.spec.ts`

## Deployment

Main page: https://bundle-icon-generator-evkmx6edr-miguels-projects-1bdfeb12.vercel.app/

WebMCP test bench: https://bundle-icon-generator-evkmx6edr-miguels-projects-1bdfeb12.vercel.app/webmcp

The Vercel project has Deployment Protection enabled, so the preview requires the project's authorized Vercel session.